### PR TITLE
docs: show how model IDs plug into API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,10 @@ models.filter(m => m.tier >= Tier.Standard);       // capable models
 const routed = await fetch("https://openrouter.ai/api/v1/chat/completions", {
   body: JSON.stringify({ model: model.openRouterId, messages }), // "anthropic/claude-sonnet-4-5"
 });
-
 // Call a provider API directly with model.apiId
 const direct = await fetch("https://api.anthropic.com/v1/messages", {
   body: JSON.stringify({ model: model.apiId, messages }), // "claude-sonnet-4-5-20250929"
 });
-
 // Call Vercel AI SDK's generateText with model.apiId
 const { text } = await generateText({ model: anthropic(model.apiId), messages });
 ```


### PR DESCRIPTION
## Summary

- Adds examples at the end of Quick Start showing how `openRouterId` and `apiId` map directly to API calls (OpenRouter, direct provider APIs, Vercel AI SDK)
- Makes it clear that pickai results are immediately usable for calling models, not just informational
- Stores first `recommend()` result to reuse in the API call examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated examples to show capturing and reusing the model returned by recommend(), including assigning the top standard-tier model to a variable.
  * Added examples demonstrating accessing model identifiers and using them directly in subsequent API calls.
  * Expanded multi-provider usage demonstrations showing how to integrate the returned model across different provider APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->