### PR TITLE
fix: replace dots with dashes in Anthropic apiId

### DIFF
--- a/src/adapters/openrouter.test.ts
+++ b/src/adapters/openrouter.test.ts
@@ -25,9 +25,9 @@ describe("parseOpenRouterModel", () => {
       expect(model.openRouterId).toBe("anthropic/claude-opus-4.6");
     });
 
-    it("sets apiId by stripping provider prefix", () => {
+    it("sets apiId to the provider's actual API model ID", () => {
       const model = parseOpenRouterModel(claudeOpus);
-      expect(model.apiId).toBe("claude-opus-4.6");
+      expect(model.apiId).toBe("claude-opus-4-6");
     });
 
     it("normalizes id (dots to hyphens, no provider)", () => {
@@ -40,6 +40,11 @@ describe("parseOpenRouterModel", () => {
       expect(model.id).toBe("gpt-4o");
       expect(model.apiId).toBe("gpt-4o");
       expect(model.openRouterId).toBe("openai/gpt-4o");
+    });
+
+    it("preserves dots in apiId for non-Anthropic providers", () => {
+      const model = parseOpenRouterModel(flash);
+      expect(model.apiId).toBe("gemini-2.5-flash");
     });
   });
 

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -42,7 +42,12 @@ export interface OpenRouterModel {
  */
 export function parseOpenRouterModel(raw: OpenRouterModel): Model {
   const provider = raw.id.split("/")[0];
-  const apiId = extractDirectModelId(raw.id);
+  let apiId = extractDirectModelId(raw.id);
+  // Anthropic uses dashes in version numbers (claude-opus-4-6) while
+  // OpenRouter uses dots (anthropic/claude-opus-4.6)
+  if (provider === "anthropic") {
+    apiId = apiId.replace(/\./g, "-");
+  }
   const id = normalizeModelId(raw.id);
 
   // Strip "Provider: " prefix from name


### PR DESCRIPTION
## Summary

- **Bug**: `apiId` was stripping the OpenRouter provider prefix but preserving dots (e.g. `claude-haiku-4.5`), while Anthropic's API expects dashes (`claude-haiku-4-5`)
- **Fix**: In `parseOpenRouterModel`, replace dots with dashes when `provider === "anthropic"` — other providers (OpenAI, Google) legitimately use dots in their API IDs
- **Tests**: Updated existing assertion, added test confirming non-Anthropic providers keep dots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API model identifier formatting for different providers. Anthropic model identifiers now use dashes instead of dots in numeric suffixes, while non-Anthropic provider identifiers are preserved with their original formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->