### PR TITLE
feat!: add apiSlugs, composable enrichers, and AA slug derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 settings.local.json
+.env
 
 node_modules/
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 1.0.0
+
+### BREAKING
+
+- **`apiId` and `openRouterId` replaced by `apiSlugs` map.** `Model.apiId` is now `Model.apiSlugs.direct` (optional). `Model.openRouterId` is now `Model.apiSlugs.openRouter`. The new `ApiSlugs` interface also supports `artificialAnalysis` for benchmark data lookups.
+
+### Added
+
+- **`ApiSlugs` type** — typed interface for `apiSlugs` on `Model` with `openRouter`, `direct?`, and `artificialAnalysis?` fields.
+- **`withClassification()`** — composable enricher that adds `tier` and `costTier`. Returns `ClassifiedModel`.
+- **`withDisplayLabels()`** — composable enricher that adds `providerName`, `priceLabel`, `contextLabel`. Returns `LabeledModel`.
+- **`withAaSlug()`** — composable enricher that derives and adds `apiSlugs.artificialAnalysis` for Artificial Analysis benchmark lookups. Returns `AaSlugModel`.
+- **`scripts/check-aa-slugs.ts`** — validation script that cross-references OpenRouter fixture against live AA data to verify slug derivation accuracy.
+
+### Changed
+
+- **`EnrichedModel` decomposed** into `ClassifiedModel & LabeledModel`. `enrich()` still returns the same fields and works identically — the underlying types are just decomposed so consumers can import `ClassifiedModel` or `LabeledModel` independently.

--- a/README.md
+++ b/README.md
@@ -42,16 +42,34 @@ models.filter(m => m.tier >= Tier.Standard);       // capable models
 
 // Call the model — every result has ready-to-use IDs
 
-// Call OpenRouter with model.openRouterId
+// Call OpenRouter with model.apiSlugs.openRouter
 const routed = await fetch("https://openrouter.ai/api/v1/chat/completions", {
-  body: JSON.stringify({ model: model.openRouterId, messages }), // "anthropic/claude-sonnet-4-5"
+  body: JSON.stringify({ model: model.apiSlugs.openRouter, messages }), // "anthropic/claude-sonnet-4-5"
 });
-// Call a provider API directly with model.apiId
+// Call a provider API directly with model.apiSlugs.direct
 const direct = await fetch("https://api.anthropic.com/v1/messages", {
-  body: JSON.stringify({ model: model.apiId, messages }), // "claude-sonnet-4-5-20250929"
+  body: JSON.stringify({ model: model.apiSlugs.direct, messages }), // "claude-sonnet-4-5-20250929"
 });
-// Call Vercel AI SDK's generateText with model.apiId
-const { text } = await generateText({ model: anthropic(model.apiId), messages });
+// Call Vercel AI SDK's generateText with model.apiSlugs.direct
+const { text } = await generateText({ model: anthropic(model.apiSlugs.direct!), messages });
+```
+
+### Composable Enrichment
+
+Use individual enrichers when you only need specific fields, or compose them freely:
+
+```typescript
+import { withClassification, withAaSlug, enrich } from "pickai";
+
+// Just classification (tier + costTier)
+models.map(withClassification);
+
+// Derive Artificial Analysis slugs for benchmark lookups
+models.map(withAaSlug);
+
+// Compose: full enrichment + AA slugs
+models.map(enrich).map(withAaSlug);
+// → each model has tier, costTier, providerName, priceLabel, contextLabel, AND apiSlugs.artificialAnalysis
 ```
 
 ### Custom Profiles
@@ -93,11 +111,14 @@ pnpm update-fixture # refresh OpenRouter model fixture
 
 ```
 src/
-  adapters/   # Provider-specific parsers (OpenRouter)
-  *.ts        # One module per concern (classify, score, enrich, group, etc.)
-  *.test.ts   # Co-located tests
+  adapters/           # Provider-specific parsers (OpenRouter)
+  with-*.ts           # Composable enrichers (classification, display labels, AA slug)
+  enrich.ts           # Convenience wrapper composing with* functions
+  *.ts                # One module per concern (classify, score, group, etc.)
+  *.test.ts           # Co-located tests
 scripts/
   update-openrouter-fixture.sh
+  check-aa-slugs.ts   # Validate AA slug derivation against live data
 ```
 
 ### Testing

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,8 +8,11 @@ Data flows through a pipeline, with each step adding fields:
 
 | Type | Source | Adds |
 |------|--------|------|
-| `Model` | Adapters | `id`, `apiId`, `openRouterId`, provider, name, pricing, capabilities |
-| `EnrichedModel` | `.map(enrich)` | `tier`, `costTier`, `providerName`, `priceLabel`, `contextLabel` |
+| `Model` | Adapters | `id`, `apiSlugs` (`openRouter`, `direct?`, `artificialAnalysis?`), provider, name, pricing, capabilities |
+| `ClassifiedModel` | `.map(withClassification)` | `tier`, `costTier` |
+| `LabeledModel` | `.map(withDisplayLabels)` | `providerName`, `priceLabel`, `contextLabel` |
+| `EnrichedModel` | `.map(enrich)` | All of `ClassifiedModel` + `LabeledModel` |
+| `AaSlugModel` | `.map(withAaSlug)` | `apiSlugs.artificialAnalysis` (required string) |
 | `ScoredModel<T>` | `recommend()`, `scoreModels()` | `score` (0-1) |
 | `ProviderGroup<T>` | `groupByProvider()` | `provider`, `providerName`, `models: T[]` |
 
@@ -17,13 +20,18 @@ Generic types preserve what you pass in — score `EnrichedModel[]` and you get 
 
 ### Model
 
-Every model carries three pre-computed IDs for different calling conventions:
+Every model carries pre-computed API identifiers in `apiSlugs`:
 
 ```typescript
+interface ApiSlugs {
+  openRouter: string;              // "anthropic/claude-sonnet-4-5"
+  direct?: string;                 // "claude-sonnet-4-5-20250929"
+  artificialAnalysis?: string;     // "claude-sonnet-4-5" (populated by withAaSlug())
+}
+
 interface Model {
   id: string;            // Base identity: "claude-sonnet-4-5"
-  apiId: string;         // For direct APIs / AI SDK: "claude-sonnet-4-5-20250929"
-  openRouterId: string;  // For OpenRouter: "anthropic/claude-sonnet-4-5"
+  apiSlugs: ApiSlugs;    // Pre-computed IDs for different calling conventions
   provider: string;      // Provider slug: "anthropic"
   name: string;          // Display name: "Claude Sonnet 4.5"
   // ...pricing, capabilities, context window, modality
@@ -102,12 +110,11 @@ recommend(models, {
 
 ## Enrichment
 
-Pre-compute display fields for UI rendering. `enrich()` decorates each model with tier, cost tier, formatted labels, and provider name:
+Pre-compute display fields for UI rendering. `enrich()` is a convenience wrapper that adds tier, cost tier, and display labels in one step:
 
 ```typescript
-import { enrich, recommend, Purpose } from "pickai";
+import { enrich } from "pickai";
 
-// Single model
 const model = enrich(rawModel);
 model.tier;          // Tier.Flagship
 model.costTier;      // Cost.Premium
@@ -115,16 +122,31 @@ model.providerName;  // "Anthropic"
 model.priceLabel;    // "$15/$75 per 1M"
 model.contextLabel;  // "200K"
 
-// Works with .map()
 const models = rawModels.map(enrich);
-
-// Chains with .filter()
-const affordable = models
-  .map(enrich)
-  .filter(m => m.costTier <= Cost.Standard);
 ```
 
-`EnrichedModel` extends `Model` — all original fields preserved, enrichment added.
+### Composable Enrichers
+
+Use individual enrichers when you only need a subset of fields:
+
+```typescript
+import { withClassification, withDisplayLabels, withAaSlug } from "pickai";
+
+// Just tier + costTier
+models.map(withClassification);
+
+// Just display labels
+models.map(withDisplayLabels);
+
+// Derive Artificial Analysis slugs for benchmark data lookups
+models.map(withAaSlug);
+// → model.apiSlugs.artificialAnalysis = "claude-opus-4-6"
+
+// Compose freely — each returns a type intersection
+models.map(enrich).map(withAaSlug);
+```
+
+`EnrichedModel` is `ClassifiedModel & LabeledModel`. All enrichers preserve original Model fields.
 
 ## Grouping
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pickai",
-  "version": "0.7.2",
+  "version": "1.0.0",
   "description": "Classify, score, and recommend AI models across providers. Normalize IDs, compare pricing, filter by capabilities. Zero deps.",
   "type": "module",
   "exports": {

--- a/scripts/check-aa-slugs.ts
+++ b/scripts/check-aa-slugs.ts
@@ -1,0 +1,123 @@
+/**
+ * Validation script: cross-reference OpenRouter fixture against live
+ * Artificial Analysis data to verify slug derivation accuracy.
+ *
+ * Usage: npx tsx scripts/check-aa-slugs.ts
+ * Requires ARTIFICIAL_ANALYSIS_API_KEY in .env (or review-kit/.env)
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { deriveAaSlug } from "../src/with-aa-slug";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Try local .env first, then fall back to review-kit
+let apiKey: string | undefined;
+for (const envPath of [
+  resolve(__dirname, "../.env"),
+  resolve(__dirname, "../../review-kit/.env"),
+]) {
+  try {
+    const envFile = readFileSync(envPath, "utf8");
+    apiKey = envFile.match(/ARTIFICIAL_ANALYSIS_API_KEY=(.+)/)?.[1]?.trim();
+    if (apiKey) break;
+  } catch {
+    // try next
+  }
+}
+
+if (!apiKey) {
+  console.error("Missing ARTIFICIAL_ANALYSIS_API_KEY in .env or review-kit/.env");
+  process.exit(1);
+}
+
+interface AAModel {
+  id: string;
+  name: string;
+  slug: string;
+  model_creator?: { name: string; slug: string };
+}
+
+interface ORModel {
+  id: string;
+  name: string;
+}
+
+async function main() {
+  // Load OpenRouter fixture
+  const fixture = JSON.parse(
+    readFileSync(resolve(__dirname, "../src/__fixtures__/openrouter-models.json"), "utf8")
+  );
+  const orModels: ORModel[] = fixture.data;
+
+  // Fetch AA models
+  const res = await fetch(
+    "https://artificialanalysis.ai/api/v2/data/llms/models",
+    { headers: { "x-api-key": apiKey! } }
+  );
+
+  if (!res.ok) {
+    console.error(`AA API error: ${res.status} ${res.statusText}`);
+    process.exit(1);
+  }
+
+  const response = await res.json();
+  const aaModels: AAModel[] = response.data;
+  const aaSlugs = new Set(aaModels.map((m) => m.slug));
+
+  // Cross-reference
+  const matches: string[] = [];
+  const mismatches: { or: string; derived: string; closest?: string }[] = [];
+  const matched = new Set<string>();
+
+  for (const or of orModels) {
+    const derived = deriveAaSlug(or.id);
+    if (aaSlugs.has(derived)) {
+      matches.push(`${or.id} -> ${derived}`);
+      matched.add(derived);
+    } else {
+      // Find closest AA slug for debugging
+      const closest = aaModels.find((aa) =>
+        aa.slug.includes(derived.split("-").slice(0, 3).join("-"))
+      );
+      mismatches.push({ or: or.id, derived, closest: closest?.slug });
+    }
+  }
+
+  const unmatchedAa = aaModels.filter((m) => !matched.has(m.slug));
+
+  console.log(`\n=== RESULTS ===`);
+  console.log(`OpenRouter models: ${orModels.length}`);
+  console.log(`AA models: ${aaModels.length}`);
+  console.log(`Exact matches: ${matches.length}`);
+  console.log(`Unmatched OR: ${mismatches.length}`);
+  console.log(`Unmatched AA: ${unmatchedAa.length}`);
+  console.log(`Match rate: ${((matches.length / orModels.length) * 100).toFixed(1)}%\n`);
+
+  if (matches.length > 0) {
+    console.log(`--- Exact matches (first 20) ---`);
+    for (const m of matches.slice(0, 20)) console.log(`  ${m}`);
+    if (matches.length > 20) console.log(`  ... and ${matches.length - 20} more`);
+  }
+
+  if (mismatches.length > 0) {
+    console.log(`\n--- Mismatches (first 30) ---`);
+    for (const m of mismatches.slice(0, 30)) {
+      const hint = m.closest ? ` (closest AA: ${m.closest})` : "";
+      console.log(`  ${m.or} -> ${m.derived}${hint}`);
+    }
+    if (mismatches.length > 30) console.log(`  ... and ${mismatches.length - 30} more`);
+  }
+
+  if (unmatchedAa.length > 0) {
+    console.log(`\n--- Unmatched AA (first 20) ---`);
+    for (const m of unmatchedAa.slice(0, 20)) {
+      console.log(`  ${m.slug} (${m.name})`);
+    }
+    if (unmatchedAa.length > 20) console.log(`  ... and ${unmatchedAa.length - 20} more`);
+  }
+}
+
+main().catch(console.error);

--- a/src/__fixtures__/openrouter-models.json
+++ b/src/__fixtures__/openrouter-models.json
@@ -1,13 +1,110 @@
 {
-  "lastUpdated": "2026-02-13T08:49:09Z",
+  "lastUpdated": "2026-03-06T22:35:05Z",
   "data": [
     {
-      "id": "minimax/minimax-m2.5",
-      "canonical_slug": "minimax/minimax-m2.5-20260211",
-      "hugging_face_id": "MiniMaxAI/MiniMax-M2.5",
-      "name": "MiniMax: MiniMax M2.5",
-      "created": 1770908502,
-      "context_length": 204800,
+      "id": "openai/gpt-5.4-pro",
+      "canonical_slug": "openai/gpt-5.4-pro-20260305",
+      "hugging_face_id": "",
+      "name": "OpenAI: GPT-5.4 Pro",
+      "created": 1772734366,
+      "context_length": 1050000,
+      "architecture": {
+        "modality": "text+image+file->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "file"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00003",
+        "completion": "0.00018",
+        "web_search": "0.01"
+      },
+      "top_provider": {
+        "context_length": 1050000,
+        "max_completion_tokens": 128000,
+        "is_moderated": true
+      },
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "presence_penalty",
+        "reasoning",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "tool_choice",
+        "tools",
+        "top_logprobs"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "openai/gpt-5.4",
+      "canonical_slug": "openai/gpt-5.4-20260305",
+      "hugging_face_id": "",
+      "name": "OpenAI: GPT-5.4",
+      "created": 1772734352,
+      "context_length": 1050000,
+      "architecture": {
+        "modality": "text+image+file->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "file"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.0000025",
+        "completion": "0.000015",
+        "web_search": "0.01",
+        "input_cache_read": "0.00000025"
+      },
+      "top_provider": {
+        "context_length": 1050000,
+        "max_completion_tokens": 128000,
+        "is_moderated": true
+      },
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "presence_penalty",
+        "reasoning",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "tool_choice",
+        "tools",
+        "top_logprobs"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "inception/mercury-2",
+      "canonical_slug": "inception/mercury-2-20260304",
+      "hugging_face_id": null,
+      "name": "Inception: Mercury 2",
+      "created": 1772636275,
+      "context_length": 128000,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -20,12 +117,152 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000012",
-        "input_cache_read": "0.00000003"
+        "prompt": "0.00000025",
+        "completion": "0.00000075",
+        "input_cache_read": "0.000000025"
       },
       "top_provider": {
-        "context_length": 204800,
+        "context_length": 128000,
+        "max_completion_tokens": 50000,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "response_format",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "openai/gpt-5.3-chat",
+      "canonical_slug": "openai/gpt-5.3-chat-20260303",
+      "hugging_face_id": "",
+      "name": "OpenAI: GPT-5.3 Chat",
+      "created": 1772564061,
+      "context_length": 128000,
+      "architecture": {
+        "modality": "text+image+file->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "file"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000175",
+        "completion": "0.000014",
+        "web_search": "0.1",
+        "input_cache_read": "0.000000175"
+      },
+      "top_provider": {
+        "context_length": 128000,
+        "max_completion_tokens": 16384,
+        "is_moderated": true
+      },
+      "supported_parameters": [
+        "frequency_penalty",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "presence_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "tool_choice",
+        "tools",
+        "top_logprobs"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "google/gemini-3.1-flash-lite-preview",
+      "canonical_slug": "google/gemini-3.1-flash-lite-preview-20260303",
+      "hugging_face_id": "",
+      "name": "Google: Gemini 3.1 Flash Lite Preview",
+      "created": 1772512673,
+      "context_length": 1048576,
+      "architecture": {
+        "modality": "text+image+file+audio+video->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "video",
+          "file",
+          "audio"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Gemini",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000025",
+        "completion": "0.0000015",
+        "image": "0.00000025",
+        "audio": "0.0000005",
+        "internal_reasoning": "0.0000015",
+        "input_cache_read": "0.000000025",
+        "input_cache_write": "0.00000008333333333333334"
+      },
+      "top_provider": {
+        "context_length": 1048576,
+        "max_completion_tokens": 65536,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "bytedance-seed/seed-2.0-mini",
+      "canonical_slug": "bytedance-seed/seed-2.0-mini-20260224",
+      "hugging_face_id": "",
+      "name": "ByteDance Seed: Seed-2.0-Mini",
+      "created": 1772131107,
+      "context_length": 262144,
+      "architecture": {
+        "modality": "text+image+video->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.0000001",
+        "completion": "0.0000004"
+      },
+      "top_provider": {
+        "context_length": 262144,
         "max_completion_tokens": 131072,
         "is_moderated": false
       },
@@ -33,16 +270,671 @@
         "frequency_penalty",
         "include_reasoning",
         "max_tokens",
+        "reasoning",
+        "response_format",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "google/gemini-3.1-flash-image-preview",
+      "canonical_slug": "google/gemini-3.1-flash-image-preview-20260226",
+      "hugging_face_id": "",
+      "name": "Google: Nano Banana 2 (Gemini 3.1 Flash Image Preview)",
+      "created": 1772119558,
+      "context_length": 65536,
+      "architecture": {
+        "modality": "text+image->text+image",
+        "input_modalities": [
+          "image",
+          "text"
+        ],
+        "output_modalities": [
+          "image",
+          "text"
+        ],
+        "tokenizer": "Gemini",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.0000005",
+        "completion": "0.000003"
+      },
+      "top_provider": {
+        "context_length": 65536,
+        "max_completion_tokens": 65536,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "qwen/qwen3.5-35b-a3b",
+      "canonical_slug": "qwen/qwen3.5-35b-a3b-20260224",
+      "hugging_face_id": "Qwen/Qwen3.5-35B-A3B",
+      "name": "Qwen: Qwen3.5-35B-A3B",
+      "created": 1772053822,
+      "context_length": 262144,
+      "architecture": {
+        "modality": "text+image+video->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.0000001625",
+        "completion": "0.0000013"
+      },
+      "top_provider": {
+        "context_length": 262144,
+        "max_completion_tokens": 65536,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
         "presence_penalty",
         "reasoning",
         "repetition_penalty",
         "response_format",
         "seed",
         "stop",
+        "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
         "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "qwen/qwen3.5-27b",
+      "canonical_slug": "qwen/qwen3.5-27b-20260224",
+      "hugging_face_id": "Qwen/Qwen3.5-27B",
+      "name": "Qwen: Qwen3.5-27B",
+      "created": 1772053810,
+      "context_length": 262144,
+      "architecture": {
+        "modality": "text+image+video->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000000195",
+        "completion": "0.00000156"
+      },
+      "top_provider": {
+        "context_length": 262144,
+        "max_completion_tokens": 65536,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "reasoning",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "qwen/qwen3.5-122b-a10b",
+      "canonical_slug": "qwen/qwen3.5-122b-a10b-20260224",
+      "hugging_face_id": "Qwen/Qwen3.5-122B-A10B",
+      "name": "Qwen: Qwen3.5-122B-A10B",
+      "created": 1772053789,
+      "context_length": 262144,
+      "architecture": {
+        "modality": "text+image+video->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000026",
+        "completion": "0.00000208"
+      },
+      "top_provider": {
+        "context_length": 262144,
+        "max_completion_tokens": 65536,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "reasoning",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "qwen/qwen3.5-flash-02-23",
+      "canonical_slug": "qwen/qwen3.5-flash-20260224",
+      "hugging_face_id": null,
+      "name": "Qwen: Qwen3.5-Flash",
+      "created": 1772053776,
+      "context_length": 1000000,
+      "architecture": {
+        "modality": "text+image+video->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.0000001",
+        "completion": "0.0000004"
+      },
+      "top_provider": {
+        "context_length": 1000000,
+        "max_completion_tokens": 65536,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "presence_penalty",
+        "reasoning",
+        "response_format",
+        "seed",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "liquid/lfm-2-24b-a2b",
+      "canonical_slug": "liquid/lfm-2-24b-a2b-20260224",
+      "hugging_face_id": "LiquidAI/LFM2-24B-A2B",
+      "name": "LiquidAI: LFM2-24B-A2B",
+      "created": 1772048711,
+      "context_length": 32768,
+      "architecture": {
+        "modality": "text->text",
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000003",
+        "completion": "0.00000012"
+      },
+      "top_provider": {
+        "context_length": 32768,
+        "max_completion_tokens": null,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "frequency_penalty",
+        "logit_bias",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "repetition_penalty",
+        "stop",
+        "temperature",
+        "top_k",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "google/gemini-3.1-pro-preview-customtools",
+      "canonical_slug": "google/gemini-3.1-pro-preview-customtools-20260219",
+      "hugging_face_id": null,
+      "name": "Google: Gemini 3.1 Pro Preview Custom Tools",
+      "created": 1772045923,
+      "context_length": 1048576,
+      "architecture": {
+        "modality": "text+image+file+audio+video->text",
+        "input_modalities": [
+          "text",
+          "audio",
+          "image",
+          "video",
+          "file"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Gemini",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000002",
+        "completion": "0.000012",
+        "image": "0.000002",
+        "audio": "0.000002",
+        "internal_reasoning": "0.000012",
+        "input_cache_read": "0.0000002",
+        "input_cache_write": "0.000000375"
+      },
+      "top_provider": {
+        "context_length": 1048576,
+        "max_completion_tokens": 65536,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "openai/gpt-5.3-codex",
+      "canonical_slug": "openai/gpt-5.3-codex-20260224",
+      "hugging_face_id": "",
+      "name": "OpenAI: GPT-5.3-Codex",
+      "created": 1771959164,
+      "context_length": 400000,
+      "architecture": {
+        "modality": "text+image->text",
+        "input_modalities": [
+          "text",
+          "image"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "GPT",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000175",
+        "completion": "0.000014",
+        "web_search": "0.01",
+        "input_cache_read": "0.000000175"
+      },
+      "top_provider": {
+        "context_length": 400000,
+        "max_completion_tokens": 128000,
+        "is_moderated": true
+      },
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "response_format",
+        "seed",
+        "structured_outputs",
+        "tool_choice",
+        "tools"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "aion-labs/aion-2.0",
+      "canonical_slug": "aion-labs/aion-2.0-20260223",
+      "hugging_face_id": null,
+      "name": "AionLabs: Aion-2.0",
+      "created": 1771881306,
+      "context_length": 131072,
+      "architecture": {
+        "modality": "text->text",
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.0000008",
+        "completion": "0.0000016",
+        "input_cache_read": "0.0000002"
+      },
+      "top_provider": {
+        "context_length": 131072,
+        "max_completion_tokens": 32768,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "temperature",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "google/gemini-3.1-pro-preview",
+      "canonical_slug": "google/gemini-3.1-pro-preview-20260219",
+      "hugging_face_id": "",
+      "name": "Google: Gemini 3.1 Pro Preview",
+      "created": 1771509627,
+      "context_length": 1048576,
+      "architecture": {
+        "modality": "text+image+file+audio+video->text",
+        "input_modalities": [
+          "audio",
+          "file",
+          "image",
+          "text",
+          "video"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Gemini",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000002",
+        "completion": "0.000012",
+        "image": "0.000002",
+        "audio": "0.000002",
+        "internal_reasoning": "0.000012",
+        "input_cache_read": "0.0000002",
+        "input_cache_write": "0.000000375"
+      },
+      "top_provider": {
+        "context_length": 1048576,
+        "max_completion_tokens": 65536,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "anthropic/claude-sonnet-4.6",
+      "canonical_slug": "anthropic/claude-4.6-sonnet-20260217",
+      "hugging_face_id": "",
+      "name": "Anthropic: Claude Sonnet 4.6",
+      "created": 1771342990,
+      "context_length": 1000000,
+      "architecture": {
+        "modality": "text+image->text",
+        "input_modalities": [
+          "text",
+          "image"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Claude",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000003",
+        "completion": "0.000015",
+        "web_search": "0.01",
+        "input_cache_read": "0.0000003",
+        "input_cache_write": "0.00000375"
+      },
+      "top_provider": {
+        "context_length": 1000000,
+        "max_completion_tokens": 128000,
+        "is_moderated": true
+      },
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "response_format",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+        "verbosity"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "qwen/qwen3.5-plus-02-15",
+      "canonical_slug": "qwen/qwen3.5-plus-20260216",
+      "hugging_face_id": "",
+      "name": "Qwen: Qwen3.5 Plus 2026-02-15",
+      "created": 1771229416,
+      "context_length": 1000000,
+      "architecture": {
+        "modality": "text+image+video->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000026",
+        "completion": "0.00000156"
+      },
+      "top_provider": {
+        "context_length": 1000000,
+        "max_completion_tokens": 65536,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "presence_penalty",
+        "reasoning",
+        "response_format",
+        "seed",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "qwen/qwen3.5-397b-a17b",
+      "canonical_slug": "qwen/qwen3.5-397b-a17b-20260216",
+      "hugging_face_id": "Qwen/Qwen3.5-397B-A17B",
+      "name": "Qwen: Qwen3.5 397B A17B",
+      "created": 1771223018,
+      "context_length": 262144,
+      "architecture": {
+        "modality": "text+image+video->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000039",
+        "completion": "0.00000234"
+      },
+      "top_provider": {
+        "context_length": 262144,
+        "max_completion_tokens": 65536,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "reasoning",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "minimax/minimax-m2.5",
+      "canonical_slug": "minimax/minimax-m2.5-20260211",
+      "hugging_face_id": "MiniMaxAI/MiniMax-M2.5",
+      "name": "MiniMax: MiniMax M2.5",
+      "created": 1770908502,
+      "context_length": 196608,
+      "architecture": {
+        "modality": "text->text",
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Other",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000000295",
+        "completion": "0.0000012",
+        "input_cache_read": "0.00000003"
+      },
+      "top_provider": {
+        "context_length": 196608,
+        "max_completion_tokens": 196608,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
+        "parallel_tool_calls",
+        "presence_penalty",
+        "reasoning",
+        "reasoning_effort",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -72,7 +964,7 @@
       },
       "top_provider": {
         "context_length": 202752,
-        "max_completion_tokens": 131072,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -117,12 +1009,12 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000012",
-        "completion": "0.000006"
+        "prompt": "0.00000078",
+        "completion": "0.0000039"
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": 32768,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -137,50 +1029,6 @@
         "tool_choice",
         "tools",
         "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "openrouter/aurora-alpha",
-      "canonical_slug": "openrouter/aurora-alpha",
-      "hugging_face_id": "",
-      "name": "Aurora Alpha",
-      "created": 1770611225,
-      "context_length": 128000,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0",
-        "completion": "0",
-        "request": "0",
-        "image": "0",
-        "web_search": "0",
-        "internal_reasoning": "0"
-      },
-      "top_provider": {
-        "context_length": 128000,
-        "max_completion_tokens": 50000,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "include_reasoning",
-        "max_tokens",
-        "reasoning",
-        "reasoning_effort",
-        "response_format",
-        "structured_outputs",
-        "temperature",
-        "tool_choice",
-        "tools"
       ],
       "expiration_date": null
     },
@@ -250,9 +1098,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000007",
-        "completion": "0.0000003",
-        "input_cache_read": "0.000000035"
+        "prompt": "0.00000012",
+        "completion": "0.00000075",
+        "input_cache_read": "0.00000006"
       },
       "top_provider": {
         "context_length": 262144,
@@ -425,7 +1273,11 @@
       },
       "pricing": {
         "prompt": "0",
-        "completion": "0"
+        "completion": "0",
+        "request": "0",
+        "image": "0",
+        "web_search": "0",
+        "internal_reasoning": "0"
       },
       "top_provider": {
         "context_length": 131000,
@@ -464,12 +1316,12 @@
       },
       "pricing": {
         "prompt": "0.00000045",
-        "completion": "0.00000225",
-        "input_cache_read": "0.000000070000002"
+        "completion": "0.0000022",
+        "input_cache_read": "0.000000225"
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": null,
+        "max_completion_tokens": 65535,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -498,10 +1350,10 @@
       "expiration_date": null
     },
     {
-      "id": "upstage/solar-pro-3:free",
+      "id": "upstage/solar-pro-3",
       "canonical_slug": "upstage/solar-pro-3",
       "hugging_face_id": "",
-      "name": "Upstage: Solar Pro 3 (free)",
+      "name": "Upstage: Solar Pro 3",
       "created": 1769481200,
       "context_length": 128000,
       "architecture": {
@@ -516,8 +1368,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0",
-        "completion": "0"
+        "prompt": "0.00000015",
+        "completion": "0.0000006",
+        "input_cache_read": "0.000000015"
       },
       "top_provider": {
         "context_length": 128000,
@@ -534,7 +1387,7 @@
         "tool_choice",
         "tools"
       ],
-      "expiration_date": "2026-03-02"
+      "expiration_date": null
     },
     {
       "id": "minimax/minimax-m2-her",
@@ -914,7 +1767,7 @@
         "top_k",
         "top_p"
       ],
-      "expiration_date": null
+      "expiration_date": "2026-03-23"
     },
     {
       "id": "allenai/olmo-3.1-32b-instruct",
@@ -1070,7 +1923,7 @@
       "pricing": {
         "prompt": "0.00000027",
         "completion": "0.00000095",
-        "input_cache_read": "0.0000000299999997"
+        "input_cache_read": "0.0000000290000007"
       },
       "top_provider": {
         "context_length": 196608,
@@ -1119,26 +1972,23 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000004",
-        "completion": "0.0000015",
-        "input_cache_read": "0.0000002"
+        "prompt": "0.00000038",
+        "completion": "0.00000198",
+        "input_cache_read": "0.00000019"
       },
       "top_provider": {
         "context_length": 202752,
-        "max_completion_tokens": 65535,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
         "logit_bias",
-        "logprobs",
         "max_tokens",
         "min_p",
-        "parallel_tool_calls",
         "presence_penalty",
         "reasoning",
-        "reasoning_effort",
         "repetition_penalty",
         "response_format",
         "seed",
@@ -1148,7 +1998,6 @@
         "tool_choice",
         "tools",
         "top_k",
-        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -1186,7 +2035,7 @@
       },
       "top_provider": {
         "context_length": 1048576,
-        "max_completion_tokens": 65535,
+        "max_completion_tokens": 65536,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -1307,7 +2156,7 @@
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": null,
+        "max_completion_tokens": 65536,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -1406,7 +2255,6 @@
         "response_format",
         "seed",
         "stop",
-        "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
@@ -1560,20 +2408,18 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000005",
-        "completion": "0.00000022",
-        "input_cache_read": "0.000000025"
+        "prompt": "0.0000004",
+        "completion": "0.000002"
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "supported_parameters": [
         "frequency_penalty",
         "max_tokens",
         "presence_penalty",
-        "repetition_penalty",
         "response_format",
         "seed",
         "stop",
@@ -1581,7 +2427,6 @@
         "temperature",
         "tool_choice",
         "tools",
-        "top_k",
         "top_p"
       ],
       "expiration_date": null
@@ -1656,7 +2501,6 @@
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
-        "logit_bias",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -1751,6 +2595,8 @@
         "stop",
         "structured_outputs",
         "temperature",
+        "tool_choice",
+        "tools",
         "top_k",
         "top_p"
       ],
@@ -1901,11 +2747,8 @@
       },
       "supported_parameters": [
         "frequency_penalty",
-        "logit_bias",
         "max_tokens",
-        "min_p",
         "presence_penalty",
-        "repetition_penalty",
         "response_format",
         "seed",
         "stop",
@@ -1913,7 +2756,6 @@
         "temperature",
         "tool_choice",
         "tools",
-        "top_k",
         "top_p"
       ],
       "expiration_date": null
@@ -2148,13 +2990,13 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000027",
-        "completion": "0.00000041",
-        "input_cache_read": "0.000000135"
+        "prompt": "0.0000004",
+        "completion": "0.0000012",
+        "input_cache_read": "0.0000002"
       },
       "top_provider": {
         "context_length": 163840,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": 163840,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -2162,6 +3004,7 @@
         "include_reasoning",
         "logit_bias",
         "max_tokens",
+        "min_p",
         "presence_penalty",
         "reasoning",
         "repetition_penalty",
@@ -2195,8 +3038,7 @@
       },
       "pricing": {
         "prompt": "0.00000025",
-        "completion": "0.00000038",
-        "input_cache_read": "0.000000125"
+        "completion": "0.0000004"
       },
       "top_provider": {
         "context_length": 163840,
@@ -2257,99 +3099,6 @@
         "frequency_penalty",
         "include_reasoning",
         "logit_bias",
-        "max_tokens",
-        "presence_penalty",
-        "reasoning",
-        "repetition_penalty",
-        "response_format",
-        "seed",
-        "stop",
-        "structured_outputs",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_k",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "tngtech/tng-r1t-chimera:free",
-      "canonical_slug": "tngtech/tng-r1t-chimera",
-      "hugging_face_id": null,
-      "name": "TNG: R1T Chimera (free)",
-      "created": 1764184161,
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0",
-        "completion": "0"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": 65536,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "include_reasoning",
-        "max_tokens",
-        "presence_penalty",
-        "reasoning",
-        "repetition_penalty",
-        "response_format",
-        "seed",
-        "stop",
-        "structured_outputs",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_k",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "tngtech/tng-r1t-chimera",
-      "canonical_slug": "tngtech/tng-r1t-chimera",
-      "hugging_face_id": null,
-      "name": "TNG: R1T Chimera",
-      "created": 1764184161,
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000025",
-        "completion": "0.00000085",
-        "input_cache_read": "0.000000125"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": 65536,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "include_reasoning",
         "max_tokens",
         "presence_penalty",
         "reasoning",
@@ -2499,7 +3248,7 @@
         "top_k",
         "top_p"
       ],
-      "expiration_date": null
+      "expiration_date": "2026-03-23"
     },
     {
       "id": "allenai/olmo-3-7b-think",
@@ -2544,7 +3293,7 @@
         "top_k",
         "top_p"
       ],
-      "expiration_date": null
+      "expiration_date": "2026-03-23"
     },
     {
       "id": "google/gemini-3-pro-image-preview",
@@ -2688,7 +3437,7 @@
         "tools",
         "top_p"
       ],
-      "expiration_date": null
+      "expiration_date": "2026-03-09"
     },
     {
       "id": "deepcogito/cogito-v2.1-671b",
@@ -2931,7 +3680,9 @@
       },
       "supported_parameters": [
         "frequency_penalty",
+        "logit_bias",
         "max_tokens",
+        "min_p",
         "presence_penalty",
         "repetition_penalty",
         "response_format",
@@ -2952,7 +3703,7 @@
       "hugging_face_id": "moonshotai/Kimi-K2-Thinking",
       "name": "MoonshotAI: Kimi K2 Thinking",
       "created": 1762440622,
-      "context_length": 262144,
+      "context_length": 131072,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -2965,13 +3716,13 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000004",
-        "completion": "0.00000175",
-        "input_cache_read": "0.0000002"
+        "prompt": "0.00000047",
+        "completion": "0.000002",
+        "input_cache_read": "0.000000141"
       },
       "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 65535,
+        "context_length": 131072,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -3275,13 +4026,15 @@
       },
       "top_provider": {
         "context_length": 196608,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": 196608,
         "is_moderated": false
       },
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
+        "logit_bias",
         "max_tokens",
+        "min_p",
         "presence_penalty",
         "reasoning",
         "repetition_penalty",
@@ -3326,23 +4079,16 @@
         "is_moderated": false
       },
       "supported_parameters": [
-        "frequency_penalty",
-        "logit_bias",
         "max_tokens",
-        "min_p",
         "presence_penalty",
-        "repetition_penalty",
         "response_format",
         "seed",
-        "stop",
-        "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
-        "top_k",
         "top_p"
       ],
-      "expiration_date": null
+      "expiration_date": "2026-02-25"
     },
     {
       "id": "liquid/lfm2-8b-a1b",
@@ -3546,7 +4292,7 @@
       "top_provider": {
         "context_length": 200000,
         "max_completion_tokens": 64000,
-        "is_moderated": false
+        "is_moderated": true
       },
       "supported_parameters": [
         "include_reasoning",
@@ -3899,7 +4645,7 @@
       "id": "google/gemini-2.5-flash-image",
       "canonical_slug": "google/gemini-2.5-flash-image",
       "hugging_face_id": "",
-      "name": "Google: Gemini 2.5 Flash Image (Nano Banana)",
+      "name": "Google: Nano Banana (Gemini 2.5 Flash Image)",
       "created": 1759870431,
       "context_length": 32768,
       "architecture": {
@@ -3933,6 +4679,7 @@
         "max_tokens",
         "response_format",
         "seed",
+        "stop",
         "structured_outputs",
         "temperature",
         "top_p"
@@ -4084,7 +4831,7 @@
       "hugging_face_id": "",
       "name": "Z.ai: GLM 4.6",
       "created": 1759235576,
-      "context_length": 202752,
+      "context_length": 204800,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -4097,13 +4844,12 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000035",
-        "completion": "0.0000015",
-        "input_cache_read": "0.000000175"
+        "prompt": "0.00000039",
+        "completion": "0.0000019"
       },
       "top_provider": {
-        "context_length": 202752,
-        "max_completion_tokens": 65536,
+        "context_length": 204800,
+        "max_completion_tokens": 204800,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -4251,7 +4997,9 @@
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
+        "logit_bias",
         "max_tokens",
+        "min_p",
         "presence_penalty",
         "reasoning",
         "repetition_penalty",
@@ -4345,57 +5093,6 @@
       "expiration_date": null
     },
     {
-      "id": "google/gemini-2.5-flash-preview-09-2025",
-      "canonical_slug": "google/gemini-2.5-flash-preview-09-2025",
-      "hugging_face_id": "",
-      "name": "Google: Gemini 2.5 Flash Preview 09-2025",
-      "created": 1758820178,
-      "context_length": 1048576,
-      "architecture": {
-        "modality": "text+image+file+audio+video->text",
-        "input_modalities": [
-          "image",
-          "file",
-          "text",
-          "audio",
-          "video"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Gemini",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000025",
-        "image": "0.0000003",
-        "audio": "0.000001",
-        "internal_reasoning": "0.0000025",
-        "input_cache_read": "0.00000003",
-        "input_cache_write": "0.00000008333333333333334"
-      },
-      "top_provider": {
-        "context_length": 1048576,
-        "max_completion_tokens": 65536,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "include_reasoning",
-        "max_tokens",
-        "reasoning",
-        "response_format",
-        "seed",
-        "stop",
-        "structured_outputs",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ],
-      "expiration_date": "2026-02-17"
-    },
-    {
       "id": "google/gemini-2.5-flash-lite-preview-09-2025",
       "canonical_slug": "google/gemini-2.5-flash-lite-preview-09-2025",
       "hugging_face_id": "",
@@ -4428,7 +5125,7 @@
       },
       "top_provider": {
         "context_length": 1048576,
-        "max_completion_tokens": 65535,
+        "max_completion_tokens": 65536,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -4570,7 +5267,7 @@
       },
       "top_provider": {
         "context_length": 262144,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": 32768,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -4604,9 +5301,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.000001",
-        "completion": "0.000005",
-        "input_cache_read": "0.0000002"
+        "prompt": "0.00000065",
+        "completion": "0.00000325",
+        "input_cache_read": "0.00000013"
       },
       "top_provider": {
         "context_length": 1000000,
@@ -4746,6 +5443,7 @@
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
+        "logit_bias",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -4838,14 +5536,22 @@
         "is_moderated": false
       },
       "supported_parameters": [
+        "frequency_penalty",
         "include_reasoning",
+        "logit_bias",
         "max_tokens",
+        "min_p",
+        "presence_penalty",
         "reasoning",
+        "repetition_penalty",
         "response_format",
+        "seed",
+        "stop",
         "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
+        "top_k",
         "top_p"
       ],
       "expiration_date": null
@@ -4869,9 +5575,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000015",
-        "input_cache_read": "0.00000006"
+        "prompt": "0.000000195",
+        "completion": "0.000000975",
+        "input_cache_read": "0.000000039"
       },
       "top_provider": {
         "context_length": 1000000,
@@ -4886,50 +5592,6 @@
         "temperature",
         "tool_choice",
         "tools",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "opengvlab/internvl3-78b",
-      "canonical_slug": "opengvlab/internvl3-78b",
-      "hugging_face_id": "OpenGVLab/InternVL3-78B",
-      "name": "OpenGVLab: InternVL3 78B",
-      "created": 1757962555,
-      "context_length": 32768,
-      "architecture": {
-        "modality": "text+image->text",
-        "input_modalities": [
-          "image",
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000015",
-        "completion": "0.0000006",
-        "input_cache_read": "0.000000075"
-      },
-      "top_provider": {
-        "context_length": 32768,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "max_tokens",
-        "presence_penalty",
-        "repetition_penalty",
-        "response_format",
-        "seed",
-        "stop",
-        "structured_outputs",
-        "temperature",
-        "top_k",
         "top_p"
       ],
       "expiration_date": null
@@ -5095,52 +5757,24 @@
       },
       "top_provider": {
         "context_length": 131072,
-        "max_completion_tokens": 32768,
+        "max_completion_tokens": 131072,
         "is_moderated": false
       },
       "supported_parameters": [
+        "frequency_penalty",
+        "logit_bias",
         "max_tokens",
-        "temperature",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "qwen/qwen-plus-2025-07-28",
-      "canonical_slug": "qwen/qwen-plus-2025-07-28",
-      "hugging_face_id": "",
-      "name": "Qwen: Qwen Plus 0728",
-      "created": 1757347599,
-      "context_length": 1000000,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Qwen3",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000004",
-        "completion": "0.0000012"
-      },
-      "top_provider": {
-        "context_length": 1000000,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "max_tokens",
+        "min_p",
         "presence_penalty",
+        "repetition_penalty",
         "response_format",
         "seed",
+        "stop",
         "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
+        "top_k",
         "top_p"
       ],
       "expiration_date": null
@@ -5164,8 +5798,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000004",
-        "completion": "0.0000012"
+        "prompt": "0.00000026",
+        "completion": "0.00000078"
       },
       "top_provider": {
         "context_length": 1000000,
@@ -5177,6 +5811,46 @@
         "max_tokens",
         "presence_penalty",
         "reasoning",
+        "response_format",
+        "seed",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p"
+      ],
+      "expiration_date": null
+    },
+    {
+      "id": "qwen/qwen-plus-2025-07-28",
+      "canonical_slug": "qwen/qwen-plus-2025-07-28",
+      "hugging_face_id": "",
+      "name": "Qwen: Qwen Plus 0728",
+      "created": 1757347599,
+      "context_length": 1000000,
+      "architecture": {
+        "modality": "text->text",
+        "input_modalities": [
+          "text"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Qwen3",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.00000026",
+        "completion": "0.00000078"
+      },
+      "top_provider": {
+        "context_length": 1000000,
+        "max_completion_tokens": 32768,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "max_tokens",
+        "presence_penalty",
         "response_format",
         "seed",
         "structured_outputs",
@@ -5258,7 +5932,6 @@
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
-        "logit_bias",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -5281,7 +5954,7 @@
       "hugging_face_id": "moonshotai/Kimi-K2-Instruct-0905",
       "name": "MoonshotAI: Kimi K2 0905",
       "created": 1757021147,
-      "context_length": 262144,
+      "context_length": 131072,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -5294,13 +5967,13 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000039",
-        "completion": "0.0000019",
-        "input_cache_read": "0.000000195"
+        "prompt": "0.0000004",
+        "completion": "0.000002",
+        "input_cache_read": "0.00000015"
       },
       "top_provider": {
-        "context_length": 262144,
-        "max_completion_tokens": 262144,
+        "context_length": 131072,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -5396,12 +6069,15 @@
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
+        "logit_bias",
         "max_tokens",
+        "min_p",
         "presence_penalty",
         "reasoning",
         "repetition_penalty",
         "response_format",
         "seed",
+        "stop",
         "structured_outputs",
         "temperature",
         "tool_choice",
@@ -5476,13 +6152,12 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000011",
-        "completion": "0.00000038",
-        "input_cache_read": "0.000000055"
+        "prompt": "0.00000013",
+        "completion": "0.0000004"
       },
       "top_provider": {
         "context_length": 131072,
-        "max_completion_tokens": 131072,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -5493,12 +6168,7 @@
         "reasoning",
         "repetition_penalty",
         "response_format",
-        "seed",
-        "stop",
-        "structured_outputs",
         "temperature",
-        "tool_choice",
-        "tools",
         "top_k",
         "top_p"
       ],
@@ -6404,9 +7074,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000008",
-        "completion": "0.00000033",
-        "input_cache_read": "0.00000004"
+        "prompt": "0.00000009",
+        "completion": "0.0000003"
       },
       "top_provider": {
         "context_length": 262144,
@@ -6415,7 +7084,9 @@
       },
       "supported_parameters": [
         "frequency_penalty",
+        "logit_bias",
         "max_tokens",
+        "min_p",
         "presence_penalty",
         "repetition_penalty",
         "response_format",
@@ -6449,13 +7120,13 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000035",
-        "completion": "0.00000155",
-        "input_cache_read": "0.000000175"
+        "prompt": "0.0000006",
+        "completion": "0.0000022",
+        "input_cache_read": "0.00000011"
       },
       "top_provider": {
         "context_length": 131072,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": 98304,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -6763,13 +7434,10 @@
         "is_moderated": false
       },
       "supported_parameters": [
-        "frequency_penalty",
         "max_tokens",
-        "presence_penalty",
         "repetition_penalty",
         "response_format",
         "seed",
-        "stop",
         "structured_outputs",
         "temperature",
         "tool_choice",
@@ -6918,7 +7586,6 @@
         "tool_choice",
         "tools",
         "top_k",
-        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -6968,7 +7635,7 @@
       "hugging_face_id": "moonshotai/Kimi-K2-Instruct",
       "name": "MoonshotAI: Kimi K2 0711",
       "created": 1752263252,
-      "context_length": 131072,
+      "context_length": 131000,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -6981,11 +7648,11 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000005",
-        "completion": "0.0000024"
+        "prompt": "0.00000055",
+        "completion": "0.0000022"
       },
       "top_provider": {
-        "context_length": 131072,
+        "context_length": 131000,
         "max_completion_tokens": null,
         "is_moderated": false
       },
@@ -7207,12 +7874,9 @@
         "is_moderated": false
       },
       "supported_parameters": [
-        "frequency_penalty",
         "max_tokens",
-        "presence_penalty",
         "response_format",
         "seed",
-        "stop",
         "temperature",
         "top_p"
       ],
@@ -7251,48 +7915,6 @@
         "reasoning",
         "response_format",
         "structured_outputs",
-        "temperature",
-        "top_k",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "tngtech/deepseek-r1t2-chimera:free",
-      "canonical_slug": "tngtech/deepseek-r1t2-chimera",
-      "hugging_face_id": "tngtech/DeepSeek-TNG-R1T2-Chimera",
-      "name": "TNG: DeepSeek R1T2 Chimera (free)",
-      "created": 1751986985,
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "DeepSeek",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0",
-        "completion": "0"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": null,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "include_reasoning",
-        "max_tokens",
-        "presence_penalty",
-        "reasoning",
-        "repetition_penalty",
-        "seed",
-        "stop",
         "temperature",
         "top_k",
         "top_p"
@@ -7519,25 +8141,22 @@
       },
       "pricing": {
         "prompt": "0.00000025",
-        "completion": "0.000001"
+        "completion": "0.00000075",
+        "input_cache_read": "0.000000025"
       },
       "top_provider": {
         "context_length": 128000,
-        "max_completion_tokens": 16384,
+        "max_completion_tokens": 32000,
         "is_moderated": false
       },
       "supported_parameters": [
-        "frequency_penalty",
         "max_tokens",
-        "presence_penalty",
         "response_format",
         "stop",
         "structured_outputs",
         "temperature",
         "tool_choice",
-        "tools",
-        "top_k",
-        "top_p"
+        "tools"
       ],
       "expiration_date": null
     },
@@ -7920,48 +8539,6 @@
       "expiration_date": null
     },
     {
-      "id": "deepseek/deepseek-r1-0528:free",
-      "canonical_slug": "deepseek/deepseek-r1-0528",
-      "hugging_face_id": "deepseek-ai/DeepSeek-R1-0528",
-      "name": "DeepSeek: R1 0528 (free)",
-      "created": 1748455170,
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "DeepSeek",
-        "instruct_type": "deepseek-r1"
-      },
-      "pricing": {
-        "prompt": "0",
-        "completion": "0"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": 163840,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "include_reasoning",
-        "max_tokens",
-        "min_p",
-        "presence_penalty",
-        "reasoning",
-        "repetition_penalty",
-        "stop",
-        "temperature",
-        "top_k",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
       "id": "deepseek/deepseek-r1-0528",
       "canonical_slug": "deepseek/deepseek-r1-0528",
       "hugging_face_id": "deepseek-ai/DeepSeek-R1-0528",
@@ -7980,9 +8557,9 @@
         "instruct_type": "deepseek-r1"
       },
       "pricing": {
-        "prompt": "0.0000004",
-        "completion": "0.00000175",
-        "input_cache_read": "0.0000002"
+        "prompt": "0.00000045",
+        "completion": "0.00000215",
+        "input_cache_read": "0.000000225"
       },
       "top_provider": {
         "context_length": 163840,
@@ -7993,7 +8570,6 @@
         "frequency_penalty",
         "include_reasoning",
         "logit_bias",
-        "logprobs",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -8007,7 +8583,6 @@
         "tool_choice",
         "tools",
         "top_k",
-        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -8063,7 +8638,7 @@
       "hugging_face_id": "",
       "name": "Anthropic: Claude Sonnet 4",
       "created": 1747930371,
-      "context_length": 1000000,
+      "context_length": 200000,
       "architecture": {
         "modality": "text+image+file->text",
         "input_modalities": [
@@ -8085,9 +8660,9 @@
         "input_cache_write": "0.00000375"
       },
       "top_provider": {
-        "context_length": 1000000,
+        "context_length": 200000,
         "max_completion_tokens": 64000,
-        "is_moderated": false
+        "is_moderated": true
       },
       "supported_parameters": [
         "include_reasoning",
@@ -8130,12 +8705,9 @@
         "is_moderated": false
       },
       "supported_parameters": [
-        "frequency_penalty",
         "max_tokens",
-        "presence_penalty",
         "response_format",
         "seed",
-        "stop",
         "temperature",
         "top_p"
       ],
@@ -8177,53 +8749,6 @@
         "repetition_penalty",
         "stop",
         "temperature",
-        "top_k",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "nousresearch/deephermes-3-mistral-24b-preview",
-      "canonical_slug": "nousresearch/deephermes-3-mistral-24b-preview",
-      "hugging_face_id": "NousResearch/DeepHermes-3-Mistral-24B-Preview",
-      "name": "Nous: DeepHermes 3 Mistral 24B Preview",
-      "created": 1746830904,
-      "context_length": 32768,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Other",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.00000002",
-        "completion": "0.0000001",
-        "input_cache_read": "0.00000001"
-      },
-      "top_provider": {
-        "context_length": 32768,
-        "max_completion_tokens": 32768,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "include_reasoning",
-        "max_tokens",
-        "presence_penalty",
-        "reasoning",
-        "repetition_penalty",
-        "response_format",
-        "seed",
-        "stop",
-        "structured_outputs",
-        "temperature",
-        "tool_choice",
-        "tools",
         "top_k",
         "top_p"
       ],
@@ -8510,25 +9035,22 @@
       },
       "pricing": {
         "prompt": "0.00000025",
-        "completion": "0.000001"
+        "completion": "0.00000075",
+        "input_cache_read": "0.000000025"
       },
       "top_provider": {
         "context_length": 128000,
-        "max_completion_tokens": 16384,
+        "max_completion_tokens": 32000,
         "is_moderated": false
       },
       "supported_parameters": [
-        "frequency_penalty",
         "max_tokens",
-        "presence_penalty",
         "response_format",
         "stop",
         "structured_outputs",
         "temperature",
         "tool_choice",
-        "tools",
-        "top_k",
-        "top_p"
+        "tools"
       ],
       "expiration_date": null
     },
@@ -8639,9 +9161,8 @@
         "instruct_type": "qwen3"
       },
       "pricing": {
-        "prompt": "0.00000006",
-        "completion": "0.00000022",
-        "input_cache_read": "0.00000003"
+        "prompt": "0.00000008",
+        "completion": "0.00000028"
       },
       "top_provider": {
         "context_length": 40960,
@@ -8674,7 +9195,7 @@
       "hugging_face_id": "Qwen/Qwen3-8B",
       "name": "Qwen: Qwen3 8B",
       "created": 1745876632,
-      "context_length": 32000,
+      "context_length": 40960,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -8692,19 +9213,27 @@
         "input_cache_read": "0.00000005"
       },
       "top_provider": {
-        "context_length": 32000,
+        "context_length": 40960,
         "max_completion_tokens": 8192,
         "is_moderated": false
       },
       "supported_parameters": [
+        "frequency_penalty",
         "include_reasoning",
+        "logit_bias",
         "max_tokens",
+        "min_p",
+        "presence_penalty",
         "reasoning",
+        "repetition_penalty",
         "response_format",
+        "seed",
+        "stop",
         "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
+        "top_k",
         "top_p"
       ],
       "expiration_date": null
@@ -8728,9 +9257,8 @@
         "instruct_type": "qwen3"
       },
       "pricing": {
-        "prompt": "0.00000005",
-        "completion": "0.00000022",
-        "input_cache_read": "0.000000025"
+        "prompt": "0.00000006",
+        "completion": "0.00000024"
       },
       "top_provider": {
         "context_length": 40960,
@@ -8740,6 +9268,7 @@
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
+        "logprobs",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -8753,6 +9282,7 @@
         "tool_choice",
         "tools",
         "top_k",
+        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -8788,7 +9318,6 @@
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
-        "logprobs",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -8802,7 +9331,6 @@
         "tool_choice",
         "tools",
         "top_k",
-        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -8813,7 +9341,7 @@
       "hugging_face_id": "Qwen/Qwen3-235B-A22B",
       "name": "Qwen: Qwen3 235B A22B",
       "created": 1745875757,
-      "context_length": 40960,
+      "context_length": 131072,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -8826,117 +9354,24 @@
         "instruct_type": "qwen3"
       },
       "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000012",
-        "input_cache_read": "0.00000015"
+        "prompt": "0.000000455",
+        "completion": "0.00000182"
       },
       "top_provider": {
-        "context_length": 40960,
-        "max_completion_tokens": 40960,
+        "context_length": 131072,
+        "max_completion_tokens": 8192,
         "is_moderated": false
       },
       "supported_parameters": [
-        "frequency_penalty",
         "include_reasoning",
         "max_tokens",
         "presence_penalty",
         "reasoning",
-        "repetition_penalty",
         "response_format",
         "seed",
-        "stop",
-        "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
-        "top_k",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "tngtech/deepseek-r1t-chimera:free",
-      "canonical_slug": "tngtech/deepseek-r1t-chimera",
-      "hugging_face_id": "tngtech/DeepSeek-R1T-Chimera",
-      "name": "TNG: DeepSeek R1T Chimera (free)",
-      "created": 1745760875,
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "DeepSeek",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0",
-        "completion": "0"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": null,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "include_reasoning",
-        "max_tokens",
-        "presence_penalty",
-        "reasoning",
-        "repetition_penalty",
-        "seed",
-        "stop",
-        "temperature",
-        "top_k",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "tngtech/deepseek-r1t-chimera",
-      "canonical_slug": "tngtech/deepseek-r1t-chimera",
-      "hugging_face_id": "tngtech/DeepSeek-R1T-Chimera",
-      "name": "TNG: DeepSeek R1T Chimera",
-      "created": 1745760875,
-      "context_length": 163840,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "DeepSeek",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000012",
-        "input_cache_read": "0.00000015"
-      },
-      "top_provider": {
-        "context_length": 163840,
-        "max_completion_tokens": 163840,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "include_reasoning",
-        "max_tokens",
-        "presence_penalty",
-        "reasoning",
-        "repetition_penalty",
-        "response_format",
-        "seed",
-        "stop",
-        "structured_outputs",
-        "temperature",
-        "top_k",
         "top_p"
       ],
       "expiration_date": null
@@ -9412,48 +9847,6 @@
       "expiration_date": null
     },
     {
-      "id": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
-      "canonical_slug": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
-      "hugging_face_id": "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
-      "name": "NVIDIA: Llama 3.1 Nemotron Ultra 253B v1",
-      "created": 1744115059,
-      "context_length": 131072,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Llama3",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.0000006",
-        "completion": "0.0000018"
-      },
-      "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": null,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "include_reasoning",
-        "max_tokens",
-        "presence_penalty",
-        "reasoning",
-        "repetition_penalty",
-        "response_format",
-        "structured_outputs",
-        "temperature",
-        "top_k",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
       "id": "meta-llama/llama-4-maverick",
       "canonical_slug": "meta-llama/llama-4-maverick-17b-128e-instruct",
       "hugging_face_id": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
@@ -9552,7 +9945,7 @@
       "hugging_face_id": "Qwen/Qwen2.5-VL-32B-Instruct",
       "name": "Qwen: Qwen2.5 VL 32B Instruct",
       "created": 1742839838,
-      "context_length": 16384,
+      "context_length": 128000,
       "architecture": {
         "modality": "text+image->text",
         "input_modalities": [
@@ -9566,13 +9959,12 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000005",
-        "completion": "0.00000022",
-        "input_cache_read": "0.000000025"
+        "prompt": "0.0000002",
+        "completion": "0.0000006"
       },
       "top_provider": {
-        "context_length": 16384,
-        "max_completion_tokens": 16384,
+        "context_length": 128000,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -9584,7 +9976,6 @@
         "response_format",
         "seed",
         "stop",
-        "structured_outputs",
         "temperature",
         "top_k",
         "top_p"
@@ -9610,13 +10001,13 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000019",
-        "completion": "0.00000087",
-        "input_cache_read": "0.000000095"
+        "prompt": "0.0000002",
+        "completion": "0.00000077",
+        "input_cache_read": "0.00000013"
       },
       "top_provider": {
         "context_length": 163840,
-        "max_completion_tokens": 65536,
+        "max_completion_tokens": 163840,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -9729,7 +10120,7 @@
       "hugging_face_id": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
       "name": "Mistral: Mistral Small 3.1 24B",
       "created": 1742238937,
-      "context_length": 131072,
+      "context_length": 128000,
       "architecture": {
         "modality": "text+image->text",
         "input_modalities": [
@@ -9743,13 +10134,12 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000003",
-        "completion": "0.00000011",
-        "input_cache_read": "0.000000015"
+        "prompt": "0.00000035",
+        "completion": "0.00000056"
       },
       "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 131072,
+        "context_length": 128000,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -9757,13 +10147,8 @@
         "max_tokens",
         "presence_penalty",
         "repetition_penalty",
-        "response_format",
         "seed",
-        "stop",
-        "structured_outputs",
         "temperature",
-        "tool_choice",
-        "tools",
         "top_k",
         "top_p"
       ],
@@ -9843,7 +10228,7 @@
       "hugging_face_id": "google/gemma-3-4b-it",
       "name": "Google: Gemma 3 4B",
       "created": 1741905510,
-      "context_length": 96000,
+      "context_length": 131072,
       "architecture": {
         "modality": "text+image->text",
         "input_modalities": [
@@ -9857,11 +10242,11 @@
         "instruct_type": "gemma"
       },
       "pricing": {
-        "prompt": "0.00000001703012",
-        "completion": "0.0000000681536"
+        "prompt": "0.00000004",
+        "completion": "0.00000008"
       },
       "top_provider": {
-        "context_length": 96000,
+        "context_length": 131072,
         "max_completion_tokens": null,
         "is_moderated": false
       },
@@ -9937,13 +10322,12 @@
         "instruct_type": "gemma"
       },
       "pricing": {
-        "prompt": "0.00000003",
-        "completion": "0.0000001",
-        "input_cache_read": "0.000000015"
+        "prompt": "0.00000004",
+        "completion": "0.00000013"
       },
       "top_provider": {
         "context_length": 131072,
-        "max_completion_tokens": 131072,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -10359,20 +10743,18 @@
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
-        "logit_bias",
+        "logprobs",
         "max_tokens",
-        "min_p",
         "presence_penalty",
         "reasoning",
-        "repetition_penalty",
         "response_format",
-        "seed",
         "stop",
         "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
         "top_k",
+        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -10425,50 +10807,6 @@
       "expiration_date": "2026-03-03"
     },
     {
-      "id": "anthropic/claude-3.7-sonnet:thinking",
-      "canonical_slug": "anthropic/claude-3-7-sonnet-20250219",
-      "hugging_face_id": "",
-      "name": "Anthropic: Claude 3.7 Sonnet (thinking)",
-      "created": 1740422110,
-      "context_length": 200000,
-      "architecture": {
-        "modality": "text+image+file->text",
-        "input_modalities": [
-          "text",
-          "image",
-          "file"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Claude",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.000003",
-        "completion": "0.000015",
-        "web_search": "0.01",
-        "input_cache_read": "0.0000003",
-        "input_cache_write": "0.00000375"
-      },
-      "top_provider": {
-        "context_length": 200000,
-        "max_completion_tokens": 64000,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "include_reasoning",
-        "max_tokens",
-        "reasoning",
-        "stop",
-        "temperature",
-        "tool_choice",
-        "tools",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
       "id": "anthropic/claude-3.7-sonnet",
       "canonical_slug": "anthropic/claude-3-7-sonnet-20250219",
       "hugging_face_id": "",
@@ -10511,7 +10849,51 @@
         "top_k",
         "top_p"
       ],
-      "expiration_date": null
+      "expiration_date": "2026-05-05"
+    },
+    {
+      "id": "anthropic/claude-3.7-sonnet:thinking",
+      "canonical_slug": "anthropic/claude-3-7-sonnet-20250219",
+      "hugging_face_id": "",
+      "name": "Anthropic: Claude 3.7 Sonnet (thinking)",
+      "created": 1740422110,
+      "context_length": 200000,
+      "architecture": {
+        "modality": "text+image+file->text",
+        "input_modalities": [
+          "text",
+          "image",
+          "file"
+        ],
+        "output_modalities": [
+          "text"
+        ],
+        "tokenizer": "Claude",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000003",
+        "completion": "0.000015",
+        "web_search": "0.01",
+        "input_cache_read": "0.0000003",
+        "input_cache_write": "0.00000375"
+      },
+      "top_provider": {
+        "context_length": 200000,
+        "max_completion_tokens": 64000,
+        "is_moderated": false
+      },
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p"
+      ],
+      "expiration_date": "2026-05-05"
     },
     {
       "id": "mistralai/mistral-saba",
@@ -10702,9 +11084,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000021",
-        "completion": "0.00000063",
-        "input_cache_read": "0.000000042"
+        "prompt": "0.0000001365",
+        "completion": "0.0000004095",
+        "input_cache_read": "0.0000000273"
       },
       "top_provider": {
         "context_length": 131072,
@@ -10886,9 +11268,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000005",
-        "completion": "0.0000002",
-        "input_cache_read": "0.00000001"
+        "prompt": "0.0000000325",
+        "completion": "0.00000013",
+        "input_cache_read": "0.0000000065"
       },
       "top_provider": {
         "context_length": 131072,
@@ -10927,9 +11309,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.00000015",
-        "completion": "0.0000006",
-        "input_cache_read": "0.000000075"
+        "prompt": "0.0000008",
+        "completion": "0.0000008"
       },
       "top_provider": {
         "context_length": 32768,
@@ -10950,7 +11331,7 @@
         "top_k",
         "top_p"
       ],
-      "expiration_date": "2026-02-16"
+      "expiration_date": null
     },
     {
       "id": "qwen/qwen-plus",
@@ -11011,9 +11392,9 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000016",
-        "completion": "0.0000064",
-        "input_cache_read": "0.00000032"
+        "prompt": "0.00000104",
+        "completion": "0.00000416",
+        "input_cache_read": "0.000000208"
       },
       "top_provider": {
         "context_length": 32768,
@@ -11108,7 +11489,6 @@
         "response_format",
         "seed",
         "stop",
-        "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
@@ -11147,6 +11527,7 @@
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
+        "logprobs",
         "max_tokens",
         "presence_penalty",
         "reasoning",
@@ -11157,6 +11538,7 @@
         "structured_outputs",
         "temperature",
         "top_k",
+        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -11220,19 +11602,17 @@
         "instruct_type": "deepseek-r1"
       },
       "pricing": {
-        "prompt": "0.00000003",
-        "completion": "0.00000011",
-        "input_cache_read": "0.000000015"
+        "prompt": "0.0000007",
+        "completion": "0.0000008"
       },
       "top_provider": {
         "context_length": 131072,
-        "max_completion_tokens": 131072,
+        "max_completion_tokens": 16384,
         "is_moderated": false
       },
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
-        "logit_bias",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -11356,6 +11736,7 @@
       },
       "supported_parameters": [
         "frequency_penalty",
+        "logprobs",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -11366,6 +11747,7 @@
         "structured_outputs",
         "temperature",
         "top_k",
+        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -11431,9 +11813,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000003",
-        "completion": "0.0000012",
-        "input_cache_read": "0.00000015"
+        "prompt": "0.00000032",
+        "completion": "0.00000089"
       },
       "top_provider": {
         "context_length": 163840,
@@ -11449,7 +11830,6 @@
         "response_format",
         "seed",
         "stop",
-        "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
@@ -11487,6 +11867,7 @@
       },
       "supported_parameters": [
         "frequency_penalty",
+        "logprobs",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -11497,6 +11878,7 @@
         "structured_outputs",
         "temperature",
         "top_k",
+        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -11979,13 +12361,12 @@
         "instruct_type": "chatml"
       },
       "pricing": {
-        "prompt": "0.00000003",
-        "completion": "0.00000011",
-        "input_cache_read": "0.000000015"
+        "prompt": "0.00000020000000000000002",
+        "completion": "0.00000020000000000000002"
       },
       "top_provider": {
         "context_length": 32768,
-        "max_completion_tokens": 32768,
+        "max_completion_tokens": 8192,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -11995,10 +12376,8 @@
         "min_p",
         "presence_penalty",
         "repetition_penalty",
-        "response_format",
         "seed",
         "stop",
-        "structured_outputs",
         "temperature",
         "top_k",
         "top_p"
@@ -12076,14 +12455,18 @@
       },
       "supported_parameters": [
         "frequency_penalty",
+        "logprobs",
         "max_tokens",
         "presence_penalty",
+        "repetition_penalty",
         "response_format",
+        "seed",
         "stop",
         "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
+        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -12198,7 +12581,9 @@
       },
       "pricing": {
         "prompt": "0.000006",
-        "completion": "0.00003"
+        "completion": "0.00003",
+        "input_cache_read": "0.0000006",
+        "input_cache_write": "0.0000075"
       },
       "top_provider": {
         "context_length": 200000,
@@ -12250,6 +12635,7 @@
         "min_p",
         "presence_penalty",
         "repetition_penalty",
+        "response_format",
         "seed",
         "stop",
         "temperature",
@@ -12404,6 +12790,7 @@
       "supported_parameters": [
         "frequency_penalty",
         "logit_bias",
+        "logprobs",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -12416,6 +12803,7 @@
         "tool_choice",
         "tools",
         "top_k",
+        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -12464,7 +12852,7 @@
       "hugging_face_id": "meta-llama/Llama-3.2-3B-Instruct",
       "name": "Meta: Llama 3.2 3B Instruct",
       "created": 1727222400,
-      "context_length": 131072,
+      "context_length": 80000,
       "architecture": {
         "modality": "text->text",
         "input_modalities": [
@@ -12477,12 +12865,12 @@
         "instruct_type": "llama3"
       },
       "pricing": {
-        "prompt": "0.00000002",
-        "completion": "0.00000002"
+        "prompt": "0.000000051",
+        "completion": "0.00000034"
       },
       "top_provider": {
-        "context_length": 131072,
-        "max_completion_tokens": 16384,
+        "context_length": 80000,
+        "max_completion_tokens": null,
         "is_moderated": false
       },
       "supported_parameters": [
@@ -12492,7 +12880,6 @@
         "min_p",
         "presence_penalty",
         "repetition_penalty",
-        "response_format",
         "seed",
         "stop",
         "temperature",
@@ -12570,7 +12957,6 @@
       },
       "supported_parameters": [
         "frequency_penalty",
-        "logit_bias",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -12613,7 +12999,6 @@
       },
       "supported_parameters": [
         "frequency_penalty",
-        "logit_bias",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -12659,12 +13044,14 @@
       },
       "supported_parameters": [
         "frequency_penalty",
+        "logprobs",
         "max_tokens",
         "presence_penalty",
         "response_format",
         "stop",
         "structured_outputs",
         "temperature",
+        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -12784,6 +13171,7 @@
       },
       "supported_parameters": [
         "frequency_penalty",
+        "logprobs",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -12796,6 +13184,7 @@
         "tool_choice",
         "tools",
         "top_k",
+        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -12820,8 +13209,8 @@
         "instruct_type": null
       },
       "pricing": {
-        "prompt": "0.0000002",
-        "completion": "0.0000002"
+        "prompt": "0.00000020000000000000002",
+        "completion": "0.00000020000000000000002"
       },
       "top_provider": {
         "context_length": 32768,
@@ -12872,6 +13261,7 @@
       },
       "supported_parameters": [
         "frequency_penalty",
+        "logprobs",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -12882,6 +13272,7 @@
         "structured_outputs",
         "temperature",
         "top_k",
+        "top_logprobs",
         "top_p"
       ],
       "expiration_date": null
@@ -12965,50 +13356,6 @@
         "top_p"
       ],
       "expiration_date": null
-    },
-    {
-      "id": "openai/chatgpt-4o-latest",
-      "canonical_slug": "openai/chatgpt-4o-latest",
-      "hugging_face_id": null,
-      "name": "OpenAI: ChatGPT-4o",
-      "created": 1723593600,
-      "context_length": 128000,
-      "architecture": {
-        "modality": "text+image->text",
-        "input_modalities": [
-          "text",
-          "image"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "GPT",
-        "instruct_type": null
-      },
-      "pricing": {
-        "prompt": "0.000005",
-        "completion": "0.000015"
-      },
-      "top_provider": {
-        "context_length": 128000,
-        "max_completion_tokens": 16384,
-        "is_moderated": true
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "logit_bias",
-        "logprobs",
-        "max_tokens",
-        "presence_penalty",
-        "response_format",
-        "seed",
-        "stop",
-        "structured_outputs",
-        "temperature",
-        "top_logprobs",
-        "top_p"
-      ],
-      "expiration_date": "2026-02-17"
     },
     {
       "id": "sao10k/l3-lunaris-8b",
@@ -13267,7 +13614,6 @@
       },
       "supported_parameters": [
         "frequency_penalty",
-        "logit_bias",
         "max_tokens",
         "min_p",
         "presence_penalty",
@@ -13581,88 +13927,6 @@
         "seed",
         "stop",
         "structured_outputs",
-        "temperature",
-        "top_k",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "mistralai/mistral-7b-instruct",
-      "canonical_slug": "mistralai/mistral-7b-instruct",
-      "hugging_face_id": "mistralai/Mistral-7B-Instruct-v0.3",
-      "name": "Mistral: Mistral 7B Instruct",
-      "created": 1716768000,
-      "context_length": 32768,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Mistral",
-        "instruct_type": "mistral"
-      },
-      "pricing": {
-        "prompt": "0.0000002",
-        "completion": "0.0000002"
-      },
-      "top_provider": {
-        "context_length": 32768,
-        "max_completion_tokens": 4096,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "logit_bias",
-        "max_tokens",
-        "min_p",
-        "presence_penalty",
-        "repetition_penalty",
-        "stop",
-        "temperature",
-        "top_k",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "mistralai/mistral-7b-instruct-v0.3",
-      "canonical_slug": "mistralai/mistral-7b-instruct-v0.3",
-      "hugging_face_id": "mistralai/Mistral-7B-Instruct-v0.3",
-      "name": "Mistral: Mistral 7B Instruct v0.3",
-      "created": 1716768000,
-      "context_length": 32768,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Mistral",
-        "instruct_type": "mistral"
-      },
-      "pricing": {
-        "prompt": "0.0000002",
-        "completion": "0.0000002"
-      },
-      "top_provider": {
-        "context_length": 32768,
-        "max_completion_tokens": 4096,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "logit_bias",
-        "max_tokens",
-        "min_p",
-        "presence_penalty",
-        "repetition_penalty",
-        "stop",
         "temperature",
         "top_k",
         "top_p"
@@ -14239,47 +14503,6 @@
         "tool_choice",
         "tools",
         "top_logprobs",
-        "top_p"
-      ],
-      "expiration_date": null
-    },
-    {
-      "id": "mistralai/mistral-7b-instruct-v0.2",
-      "canonical_slug": "mistralai/mistral-7b-instruct-v0.2",
-      "hugging_face_id": "mistralai/Mistral-7B-Instruct-v0.2",
-      "name": "Mistral: Mistral 7B Instruct v0.2",
-      "created": 1703721600,
-      "context_length": 32768,
-      "architecture": {
-        "modality": "text->text",
-        "input_modalities": [
-          "text"
-        ],
-        "output_modalities": [
-          "text"
-        ],
-        "tokenizer": "Mistral",
-        "instruct_type": "mistral"
-      },
-      "pricing": {
-        "prompt": "0.0000002",
-        "completion": "0.0000002"
-      },
-      "top_provider": {
-        "context_length": 32768,
-        "max_completion_tokens": null,
-        "is_moderated": false
-      },
-      "supported_parameters": [
-        "frequency_penalty",
-        "logit_bias",
-        "max_tokens",
-        "min_p",
-        "presence_penalty",
-        "repetition_penalty",
-        "stop",
-        "temperature",
-        "top_k",
         "top_p"
       ],
       "expiration_date": null

--- a/src/adapters/openrouter.test.ts
+++ b/src/adapters/openrouter.test.ts
@@ -20,14 +20,14 @@ const flash: OpenRouterModel = fixture.data.find(
 
 describe("parseOpenRouterModel", () => {
   describe("ID mapping", () => {
-    it("sets openRouterId as-is from the raw id", () => {
+    it("sets apiSlugs.openRouter as-is from the raw id", () => {
       const model = parseOpenRouterModel(claudeOpus);
-      expect(model.openRouterId).toBe("anthropic/claude-opus-4.6");
+      expect(model.apiSlugs.openRouter).toBe("anthropic/claude-opus-4.6");
     });
 
-    it("sets apiId to the provider's actual API model ID", () => {
+    it("sets apiSlugs.direct to the provider's actual API model ID", () => {
       const model = parseOpenRouterModel(claudeOpus);
-      expect(model.apiId).toBe("claude-opus-4-6");
+      expect(model.apiSlugs.direct).toBe("claude-opus-4-6");
     });
 
     it("normalizes id (dots to hyphens, no provider)", () => {
@@ -38,13 +38,13 @@ describe("parseOpenRouterModel", () => {
     it("handles model IDs without dots", () => {
       const model = parseOpenRouterModel(gpt4o);
       expect(model.id).toBe("gpt-4o");
-      expect(model.apiId).toBe("gpt-4o");
-      expect(model.openRouterId).toBe("openai/gpt-4o");
+      expect(model.apiSlugs.direct).toBe("gpt-4o");
+      expect(model.apiSlugs.openRouter).toBe("openai/gpt-4o");
     });
 
-    it("preserves dots in apiId for non-Anthropic providers", () => {
+    it("preserves dots in apiSlugs.direct for non-Anthropic providers", () => {
       const model = parseOpenRouterModel(flash);
-      expect(model.apiId).toBe("gemini-2.5-flash");
+      expect(model.apiSlugs.direct).toBe("gemini-2.5-flash");
     });
   });
 
@@ -186,11 +186,11 @@ describe("parseOpenRouterCatalog", () => {
 
   it("every model has required fields", () => {
     for (const m of catalog) {
-      expect(m.id, `${m.openRouterId} missing id`).toBeTruthy();
-      expect(m.apiId, `${m.openRouterId} missing apiId`).toBeTruthy();
-      expect(m.openRouterId, `${m.openRouterId} missing openRouterId`).toBeTruthy();
-      expect(m.name, `${m.openRouterId} missing name`).toBeTruthy();
-      expect(m.provider, `${m.openRouterId} missing provider`).toBeTruthy();
+      expect(m.id, `${m.apiSlugs.openRouter} missing id`).toBeTruthy();
+      expect(m.apiSlugs.direct, `${m.apiSlugs.openRouter} missing apiSlugs.direct`).toBeTruthy();
+      expect(m.apiSlugs.openRouter, `${m.apiSlugs.openRouter} missing apiSlugs.openRouter`).toBeTruthy();
+      expect(m.name, `${m.apiSlugs.openRouter} missing name`).toBeTruthy();
+      expect(m.provider, `${m.apiSlugs.openRouter} missing provider`).toBeTruthy();
     }
   });
 
@@ -212,12 +212,12 @@ describe("parseOpenRouterCatalog", () => {
     expect(nonTextFocused.length).toBeGreaterThan(0);
 
     // Non-text models should include known image/audio generators
-    const nonTextIds = nonTextFocused.map((m) => m.openRouterId);
+    const nonTextIds = nonTextFocused.map((m) => m.apiSlugs.openRouter);
     expect(nonTextIds).toContain("openai/gpt-5-image");
   });
 
   it("well-known models are classified into expected tiers", () => {
-    const byId = new Map(catalog.map((m) => [m.openRouterId, m]));
+    const byId = new Map(catalog.map((m) => [m.apiSlugs.openRouter, m]));
 
     const opus = byId.get("anthropic/claude-opus-4.6")!;
     expect(classifyTier(opus)).toBe(Tier.Flagship);

--- a/src/adapters/openrouter.ts
+++ b/src/adapters/openrouter.ts
@@ -42,11 +42,11 @@ export interface OpenRouterModel {
  */
 export function parseOpenRouterModel(raw: OpenRouterModel): Model {
   const provider = raw.id.split("/")[0];
-  let apiId = extractDirectModelId(raw.id);
+  let direct = extractDirectModelId(raw.id);
   // Anthropic uses dashes in version numbers (claude-opus-4-6) while
   // OpenRouter uses dots (anthropic/claude-opus-4.6)
   if (provider === "anthropic") {
-    apiId = apiId.replace(/\./g, "-");
+    direct = direct.replace(/\./g, "-");
   }
   const id = normalizeModelId(raw.id);
 
@@ -61,8 +61,10 @@ export function parseOpenRouterModel(raw: OpenRouterModel): Model {
 
   return {
     id,
-    apiId,
-    openRouterId: raw.id,
+    apiSlugs: {
+      openRouter: raw.id,
+      direct,
+    },
     name,
     provider,
     contextWindow: raw.context_length,

--- a/src/enrich.test.ts
+++ b/src/enrich.test.ts
@@ -49,8 +49,7 @@ describe("enrich", () => {
   it("preserves all original Model fields", () => {
     const result = enrich(fixtures.sonnet);
     expect(result.id).toBe(fixtures.sonnet.id);
-    expect(result.apiId).toBe(fixtures.sonnet.apiId);
-    expect(result.openRouterId).toBe(fixtures.sonnet.openRouterId);
+    expect(result.apiSlugs).toEqual(fixtures.sonnet.apiSlugs);
     expect(result.name).toBe(fixtures.sonnet.name);
     expect(result.provider).toBe(fixtures.sonnet.provider);
     expect(result.pricing).toEqual(fixtures.sonnet.pricing);

--- a/src/enrich.ts
+++ b/src/enrich.ts
@@ -5,27 +5,18 @@
  * formatted strings — designed for .map():
  *
  *   const models = raw.map(enrich);
+ *
+ * Convenience wrapper over withClassification() + withDisplayLabels().
  */
 
-import type { Model, ModelTier, CostTier } from "./types";
-import { classifyTier, classifyCostTier } from "./classify";
-import { formatPricing, formatContextWindow, formatProviderName } from "./format";
+import type { Model } from "./types";
+import { withClassification, type ClassifiedModel } from "./with-classification";
+import { withDisplayLabels, type LabeledModel } from "./with-display-labels";
 
 /**
  * A Model decorated with pre-computed classification and display fields.
  */
-export interface EnrichedModel extends Model {
-  /** Capability tier: Tier.Efficient, Tier.Standard, Tier.Flagship */
-  tier: ModelTier;
-  /** Cost tier: Cost.Free through Cost.Ultra */
-  costTier: CostTier;
-  /** Human-readable provider name: "Anthropic", "OpenAI", "Google" */
-  providerName: string;
-  /** Formatted pricing: "$3/$15 per 1M" or "Free", empty string if unknown */
-  priceLabel: string;
-  /** Formatted context window: "128K", "1.0M", empty string if unknown */
-  contextLabel: string;
-}
+export type EnrichedModel = ClassifiedModel & LabeledModel;
 
 /**
  * Enrich a model with classification and formatted display fields.
@@ -36,12 +27,5 @@ export interface EnrichedModel extends Model {
  * ```
  */
 export function enrich(model: Model): EnrichedModel {
-  return {
-    ...model,
-    tier: classifyTier(model),
-    costTier: classifyCostTier(model),
-    providerName: formatProviderName(model.provider),
-    priceLabel: model.pricing ? formatPricing(model.pricing) : "",
-    contextLabel: model.contextWindow ? formatContextWindow(model.contextWindow) : "",
-  };
+  return withDisplayLabels(withClassification(model));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Types and constants
 export type {
   Model,
+  ApiSlugs,
   ScoredModel,
   ScoringCriterion,
   WeightedCriterion,
@@ -62,6 +63,14 @@ export { providerDiversity, minContextWindow, selectModels } from "./select";
 // Enrichment
 export { enrich } from "./enrich";
 export type { EnrichedModel } from "./enrich";
+
+// Composable enrichers
+export { withClassification } from "./with-classification";
+export type { ClassifiedModel } from "./with-classification";
+export { withDisplayLabels } from "./with-display-labels";
+export type { LabeledModel } from "./with-display-labels";
+export { withAaSlug } from "./with-aa-slug";
+export type { AaSlugModel } from "./with-aa-slug";
 
 // Grouping
 export { groupByProvider } from "./group";

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -33,7 +33,7 @@ describe("integration: full pipeline", () => {
     for (const m of models) {
       expect(m.id).toBeTruthy();
       expect(m.provider).toBeTruthy();
-      expect(m.openRouterId).toContain("/");
+      expect(m.apiSlugs.openRouter).toContain("/");
     }
   });
 

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -100,6 +100,13 @@ describe("smoke: main entry (pickai)", () => {
     expect(typeof mod.minContextWindow).toBe("function");
   });
 
+  it("exports composable enrichers", async () => {
+    const mod = await import("./index");
+    expect(typeof mod.withClassification).toBe("function");
+    expect(typeof mod.withDisplayLabels).toBe("function");
+    expect(typeof mod.withAaSlug).toBe("function");
+  });
+
   it("exports adapter functions from main entry", async () => {
     const mod = await import("./index");
     expect(typeof mod.parseOpenRouterModel).toBe("function");

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -6,11 +6,13 @@ import type { Model } from "./types";
 
 /** Create a minimal Model for testing with sensible defaults. */
 export function createModel(overrides: Partial<Model> = {}): Model {
+  const id = overrides.id || "test-model";
   return {
-    id: overrides.id || "test-model",
-    apiId: overrides.apiId || overrides.id || "test-model",
-    openRouterId:
-      overrides.openRouterId || `test/${overrides.id || "test-model"}`,
+    id,
+    apiSlugs: overrides.apiSlugs ?? {
+      openRouter: `test/${id}`,
+      direct: id,
+    },
     name: overrides.name || "Test Model",
     provider: overrides.provider || "test",
     contextWindow: overrides.contextWindow ?? 128000,
@@ -29,8 +31,7 @@ export const fixtures = {
   // Flagship tier
   opus: createModel({
     id: "claude-opus-4-5",
-    apiId: "claude-opus-4-5-20250929",
-    openRouterId: "anthropic/claude-opus-4-5",
+    apiSlugs: { openRouter: "anthropic/claude-opus-4-5", direct: "claude-opus-4-5-20250929" },
     name: "Claude Opus 4.5",
     provider: "anthropic",
     contextWindow: 200000,
@@ -40,8 +41,7 @@ export const fixtures = {
   }),
   gpt5Pro: createModel({
     id: "gpt-5-2-pro",
-    apiId: "gpt-5-2-pro",
-    openRouterId: "openai/gpt-5-2-pro",
+    apiSlugs: { openRouter: "openai/gpt-5-2-pro", direct: "gpt-5-2-pro" },
     name: "GPT-5.2 Pro",
     provider: "openai",
     contextWindow: 256000,
@@ -51,8 +51,7 @@ export const fixtures = {
   }),
   geminiPro: createModel({
     id: "gemini-2-5-pro",
-    apiId: "gemini-2-5-pro",
-    openRouterId: "google/gemini-2-5-pro",
+    apiSlugs: { openRouter: "google/gemini-2-5-pro", direct: "gemini-2-5-pro" },
     name: "Gemini 2.5 Pro",
     provider: "google",
     contextWindow: 1000000,
@@ -64,8 +63,7 @@ export const fixtures = {
   // Standard tier
   sonnet: createModel({
     id: "claude-sonnet-4-5",
-    apiId: "claude-sonnet-4-5-20250929",
-    openRouterId: "anthropic/claude-sonnet-4-5",
+    apiSlugs: { openRouter: "anthropic/claude-sonnet-4-5", direct: "claude-sonnet-4-5-20250929" },
     name: "Claude Sonnet 4.5",
     provider: "anthropic",
     contextWindow: 200000,
@@ -75,8 +73,7 @@ export const fixtures = {
   }),
   gpt4o: createModel({
     id: "gpt-4o",
-    apiId: "gpt-4o-2024-11-20",
-    openRouterId: "openai/gpt-4o",
+    apiSlugs: { openRouter: "openai/gpt-4o", direct: "gpt-4o-2024-11-20" },
     name: "GPT-4o",
     provider: "openai",
     contextWindow: 128000,
@@ -86,8 +83,7 @@ export const fixtures = {
   }),
   gpt52: createModel({
     id: "gpt-5-2",
-    apiId: "gpt-5-2",
-    openRouterId: "openai/gpt-5-2",
+    apiSlugs: { openRouter: "openai/gpt-5-2", direct: "gpt-5-2" },
     name: "GPT-5.2",
     provider: "openai",
     contextWindow: 256000,
@@ -99,8 +95,7 @@ export const fixtures = {
   // Efficient tier
   haiku: createModel({
     id: "claude-haiku-4-5",
-    apiId: "claude-haiku-4-5-20251001",
-    openRouterId: "anthropic/claude-haiku-4-5",
+    apiSlugs: { openRouter: "anthropic/claude-haiku-4-5", direct: "claude-haiku-4-5-20251001" },
     name: "Claude Haiku 4.5",
     provider: "anthropic",
     contextWindow: 200000,
@@ -110,8 +105,7 @@ export const fixtures = {
   }),
   gpt4oMini: createModel({
     id: "gpt-4o-mini",
-    apiId: "gpt-4o-mini-2024-07-18",
-    openRouterId: "openai/gpt-4o-mini",
+    apiSlugs: { openRouter: "openai/gpt-4o-mini", direct: "gpt-4o-mini-2024-07-18" },
     name: "GPT-4o Mini",
     provider: "openai",
     contextWindow: 128000,
@@ -121,8 +115,7 @@ export const fixtures = {
   }),
   flash: createModel({
     id: "gemini-2-5-flash",
-    apiId: "gemini-2-5-flash",
-    openRouterId: "google/gemini-2-5-flash",
+    apiSlugs: { openRouter: "google/gemini-2-5-flash", direct: "gemini-2-5-flash" },
     name: "Gemini 2.5 Flash",
     provider: "google",
     contextWindow: 1000000,
@@ -134,8 +127,7 @@ export const fixtures = {
   // Special: no tools, code-specialized
   coder: createModel({
     id: "deepseek-coder-v2",
-    apiId: "deepseek-coder-v2",
-    openRouterId: "deepseek/deepseek-coder-v2",
+    apiSlugs: { openRouter: "deepseek/deepseek-coder-v2", direct: "deepseek-coder-v2" },
     name: "DeepSeek Coder V2",
     provider: "deepseek",
     contextWindow: 128000,
@@ -147,8 +139,7 @@ export const fixtures = {
   // Special: vision-specialized output model
   imageGen: createModel({
     id: "dall-e-3",
-    apiId: "dall-e-3",
-    openRouterId: "openai/dall-e-3",
+    apiSlugs: { openRouter: "openai/dall-e-3", direct: "dall-e-3" },
     name: "DALL-E 3",
     provider: "openai",
     contextWindow: 4096,

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,23 +37,29 @@ export const Cost = {
 } as const;
 
 /**
+ * Pre-computed API identifiers for different calling conventions.
+ */
+export interface ApiSlugs {
+  /** For OpenRouter API: "anthropic/claude-sonnet-4-5" */
+  openRouter: string;
+  /** For direct provider APIs / Vercel AI SDK: "claude-sonnet-4-5-20250929" */
+  direct?: string;
+  /** For Artificial Analysis benchmark lookups: "claude-sonnet-4-5" */
+  artificialAnalysis?: string;
+}
+
+/**
  * Normalized model representation across all providers.
  *
- * Three pre-computed IDs for different calling conventions:
- * - `id` — the model's identity ("claude-sonnet-4-5", "gpt-4o", "gemini-2.5-flash")
- * - `apiId` — for direct provider APIs / Vercel AI SDK ("claude-sonnet-4-5-20250929")
- * - `openRouterId` — for OpenRouter API ("anthropic/claude-sonnet-4-5")
- *
- * All three are set once when a Model is created (by an adapter or static data).
- * Consumers just grab the one they need — no conversion at call time.
+ * `id` is the model's base identity ("claude-sonnet-4-5", "gpt-4o").
+ * `apiSlugs` holds pre-computed IDs for different calling conventions —
+ * consumers just grab the one they need, no conversion at call time.
  */
 export interface Model {
   /** The model's base identity: "claude-sonnet-4-5", "gpt-4o", "gemini-2.5-flash" */
   id: string;
-  /** For direct provider APIs and Vercel AI SDK: "claude-sonnet-4-5-20250929" */
-  apiId: string;
-  /** For OpenRouter API: "anthropic/claude-sonnet-4-5" */
-  openRouterId: string;
+  /** Pre-computed API identifiers for different calling conventions */
+  apiSlugs: ApiSlugs;
   /** Human-readable display name */
   name: string;
   /** Provider slug (e.g., "anthropic", "openai", "google") */

--- a/src/with-aa-slug.test.ts
+++ b/src/with-aa-slug.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { withAaSlug } from "./with-aa-slug";
+import { withClassification } from "./with-classification";
+import { enrich } from "./enrich";
+import { parseOpenRouterCatalog } from "./adapters/openrouter";
+import type { OpenRouterModel } from "./adapters/openrouter";
+import { createModel } from "./test-utils";
+
+function modelWithOpenRouterId(openRouterId: string) {
+  return createModel({
+    id: openRouterId.split("/").pop()!.replace(/\./g, "-").replace(/:.*/, ""),
+    apiSlugs: { openRouter: openRouterId, direct: openRouterId.split("/").pop()! },
+  });
+}
+
+describe("withAaSlug", () => {
+  describe("slug derivation", () => {
+    it("anthropic/claude-opus-4.6 -> claude-opus-4-6", () => {
+      const model = modelWithOpenRouterId("anthropic/claude-opus-4.6");
+      expect(withAaSlug(model).apiSlugs.artificialAnalysis).toBe("claude-opus-4-6");
+    });
+
+    it("openai/gpt-5.2-codex -> gpt-5-2-codex", () => {
+      const model = modelWithOpenRouterId("openai/gpt-5.2-codex");
+      expect(withAaSlug(model).apiSlugs.artificialAnalysis).toBe("gpt-5-2-codex");
+    });
+
+    it("google/gemini-2.5-flash -> gemini-2-5-flash", () => {
+      const model = modelWithOpenRouterId("google/gemini-2.5-flash");
+      expect(withAaSlug(model).apiSlugs.artificialAnalysis).toBe("gemini-2-5-flash");
+    });
+
+    it("openai/gpt-4o -> gpt-4o", () => {
+      const model = modelWithOpenRouterId("openai/gpt-4o");
+      expect(withAaSlug(model).apiSlugs.artificialAnalysis).toBe("gpt-4o");
+    });
+
+    it("strips :free suffix", () => {
+      const model = modelWithOpenRouterId("stepfun/step-3.5-flash:free");
+      expect(withAaSlug(model).apiSlugs.artificialAnalysis).toBe("step-3-5-flash");
+    });
+
+    it("strips :thinking suffix", () => {
+      const model = modelWithOpenRouterId("anthropic/claude-sonnet-4.5:thinking");
+      expect(withAaSlug(model).apiSlugs.artificialAnalysis).toBe("claude-sonnet-4-5");
+    });
+  });
+
+  it("preserves all Model fields", () => {
+    const model = modelWithOpenRouterId("anthropic/claude-opus-4.6");
+    const result = withAaSlug(model);
+    expect(result.id).toBe(model.id);
+    expect(result.apiSlugs.openRouter).toBe(model.apiSlugs.openRouter);
+    expect(result.apiSlugs.direct).toBe(model.apiSlugs.direct);
+    expect(result.name).toBe(model.name);
+    expect(result.provider).toBe(model.provider);
+  });
+
+  it("populates apiSlugs.artificialAnalysis as a string", () => {
+    const model = modelWithOpenRouterId("openai/gpt-4o");
+    const result = withAaSlug(model);
+    expect(typeof result.apiSlugs.artificialAnalysis).toBe("string");
+    expect(result.apiSlugs.artificialAnalysis.length).toBeGreaterThan(0);
+  });
+
+  describe("composability", () => {
+    it("composes with enrich()", () => {
+      const model = modelWithOpenRouterId("anthropic/claude-opus-4.6");
+      const result = withAaSlug(enrich(model));
+      expect(result.tier).toBeTruthy();
+      expect(result.providerName).toBeTruthy();
+      expect(result.apiSlugs.artificialAnalysis).toBe("claude-opus-4-6");
+    });
+
+    it("composes with withClassification()", () => {
+      const model = modelWithOpenRouterId("openai/gpt-4o");
+      const result = withAaSlug(withClassification(model));
+      expect(result.tier).toBeTruthy();
+      expect(result.apiSlugs.artificialAnalysis).toBe("gpt-4o");
+    });
+
+    it("composes with .map()", () => {
+      const models = [
+        modelWithOpenRouterId("anthropic/claude-opus-4.6"),
+        modelWithOpenRouterId("openai/gpt-4o"),
+      ];
+      const results = models.map(withAaSlug);
+      expect(results[0].apiSlugs.artificialAnalysis).toBe("claude-opus-4-6");
+      expect(results[1].apiSlugs.artificialAnalysis).toBe("gpt-4o");
+    });
+  });
+
+  describe("catalog coverage", () => {
+    const fixture = JSON.parse(
+      readFileSync(join(__dirname, "__fixtures__/openrouter-models.json"), "utf-8")
+    );
+    const catalog = parseOpenRouterCatalog(fixture);
+
+    it("every fixture model gets a truthy AA slug", () => {
+      for (const model of catalog) {
+        const result = withAaSlug(model);
+        expect(
+          result.apiSlugs.artificialAnalysis,
+          `${model.apiSlugs.openRouter} should have a truthy AA slug`
+        ).toBeTruthy();
+      }
+    });
+  });
+});

--- a/src/with-aa-slug.ts
+++ b/src/with-aa-slug.ts
@@ -1,0 +1,43 @@
+import type { Model, ApiSlugs } from "./types";
+
+export type AaSlugModel = Model & {
+  apiSlugs: ApiSlugs & { artificialAnalysis: string };
+};
+
+/**
+ * Derive the Artificial Analysis slug from an OpenRouter ID.
+ *
+ * Steps:
+ * 1. Strip provider prefix (before `/`)
+ * 2. Replace dots with hyphens
+ * 3. Strip `:variant` suffixes (`:free`, `:thinking`)
+ * 4. Lowercase (defensive)
+ */
+export function deriveAaSlug(openRouterId: string): string {
+  let slug = openRouterId;
+
+  // Strip provider prefix
+  if (slug.includes("/")) {
+    slug = slug.split("/").slice(1).join("/");
+  }
+
+  // Replace dots with hyphens
+  slug = slug.replace(/\./g, "-");
+
+  // Strip colon suffixes
+  if (slug.includes(":")) {
+    slug = slug.slice(0, slug.indexOf(":"));
+  }
+
+  return slug.toLowerCase();
+}
+
+export function withAaSlug<T extends Model>(model: T): T & AaSlugModel {
+  return {
+    ...model,
+    apiSlugs: {
+      ...model.apiSlugs,
+      artificialAnalysis: deriveAaSlug(model.apiSlugs.openRouter),
+    },
+  };
+}

--- a/src/with-classification.test.ts
+++ b/src/with-classification.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { withClassification } from "./with-classification";
+import { Tier, Cost } from "./types";
+import { createModel, fixtures } from "./test-utils";
+
+describe("withClassification", () => {
+  it("adds tier classification", () => {
+    expect(withClassification(fixtures.opus).tier).toBe(Tier.Flagship);
+    expect(withClassification(fixtures.sonnet).tier).toBe(Tier.Standard);
+    expect(withClassification(fixtures.haiku).tier).toBe(Tier.Efficient);
+  });
+
+  it("adds cost tier classification", () => {
+    expect(withClassification(fixtures.opus).costTier).toBe(Cost.Premium);
+    expect(withClassification(fixtures.sonnet).costTier).toBe(Cost.Standard);
+    expect(withClassification(fixtures.gpt4oMini).costTier).toBe(Cost.Budget);
+  });
+
+  it("preserves all original Model fields", () => {
+    const result = withClassification(fixtures.sonnet);
+    expect(result.id).toBe(fixtures.sonnet.id);
+    expect(result.apiSlugs).toEqual(fixtures.sonnet.apiSlugs);
+    expect(result.name).toBe(fixtures.sonnet.name);
+    expect(result.provider).toBe(fixtures.sonnet.provider);
+  });
+
+  it("composes with .map()", () => {
+    const classified = [fixtures.haiku, fixtures.sonnet, fixtures.opus].map(withClassification);
+    expect(classified.map((m) => m.tier)).toEqual([
+      Tier.Efficient,
+      Tier.Standard,
+      Tier.Flagship,
+    ]);
+  });
+
+  it("free model gets Cost.Free", () => {
+    const free = createModel({ pricing: { input: 0, output: 0 } });
+    expect(withClassification(free).costTier).toBe(Cost.Free);
+  });
+});

--- a/src/with-classification.ts
+++ b/src/with-classification.ts
@@ -1,0 +1,15 @@
+import type { Model, ModelTier, CostTier } from "./types";
+import { classifyTier, classifyCostTier } from "./classify";
+
+export type ClassifiedModel = Model & {
+  tier: ModelTier;
+  costTier: CostTier;
+};
+
+export function withClassification<T extends Model>(model: T): T & ClassifiedModel {
+  return {
+    ...model,
+    tier: classifyTier(model),
+    costTier: classifyCostTier(model),
+  };
+}

--- a/src/with-display-labels.test.ts
+++ b/src/with-display-labels.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { withDisplayLabels } from "./with-display-labels";
+import { createModel, fixtures } from "./test-utils";
+
+describe("withDisplayLabels", () => {
+  it("adds formatted provider name", () => {
+    expect(withDisplayLabels(fixtures.opus).providerName).toBe("Anthropic");
+    expect(withDisplayLabels(fixtures.gpt4o).providerName).toBe("OpenAI");
+    expect(withDisplayLabels(fixtures.flash).providerName).toBe("Google");
+  });
+
+  it("adds formatted price label", () => {
+    expect(withDisplayLabels(fixtures.sonnet).priceLabel).toBe("$3/$15 per 1M");
+  });
+
+  it("sets priceLabel to Free for zero pricing", () => {
+    const free = createModel({ pricing: { input: 0, output: 0 } });
+    expect(withDisplayLabels(free).priceLabel).toBe("Free");
+  });
+
+  it("sets priceLabel to empty string when pricing is undefined", () => {
+    const noPricing = createModel({ pricing: undefined });
+    expect(withDisplayLabels(noPricing).priceLabel).toBe("");
+  });
+
+  it("adds formatted context label", () => {
+    expect(withDisplayLabels(fixtures.gpt4o).contextLabel).toBe("128K");
+    expect(withDisplayLabels(fixtures.flash).contextLabel).toBe("1.0M");
+  });
+
+  it("sets contextLabel to empty string when contextWindow is undefined", () => {
+    const noCtx = createModel({ contextWindow: undefined });
+    expect(withDisplayLabels(noCtx).contextLabel).toBe("");
+  });
+
+  it("preserves all original Model fields", () => {
+    const result = withDisplayLabels(fixtures.sonnet);
+    expect(result.id).toBe(fixtures.sonnet.id);
+    expect(result.apiSlugs).toEqual(fixtures.sonnet.apiSlugs);
+    expect(result.name).toBe(fixtures.sonnet.name);
+  });
+
+  it("composes with .map()", () => {
+    const labeled = [fixtures.opus, fixtures.gpt4o].map(withDisplayLabels);
+    expect(labeled[0].providerName).toBe("Anthropic");
+    expect(labeled[1].providerName).toBe("OpenAI");
+  });
+});

--- a/src/with-display-labels.ts
+++ b/src/with-display-labels.ts
@@ -1,0 +1,17 @@
+import type { Model } from "./types";
+import { formatPricing, formatContextWindow, formatProviderName } from "./format";
+
+export type LabeledModel = Model & {
+  providerName: string;
+  priceLabel: string;
+  contextLabel: string;
+};
+
+export function withDisplayLabels<T extends Model>(model: T): T & LabeledModel {
+  return {
+    ...model,
+    providerName: formatProviderName(model.provider),
+    priceLabel: model.pricing ? formatPricing(model.pricing) : "",
+    contextLabel: model.contextWindow ? formatContextWindow(model.contextWindow) : "",
+  };
+}


### PR DESCRIPTION
## Summary

- **BREAKING:** `Model.apiId` → `Model.apiSlugs.direct`, `Model.openRouterId` → `Model.apiSlugs.openRouter`. New `ApiSlugs` interface with optional `artificialAnalysis` field.
- **Composable enrichers:** `withClassification()`, `withDisplayLabels()`, `withAaSlug()` — each returns a type intersection, composable via `.map()`. `enrich()` remains as a convenience wrapper.
- **AA slug derivation:** `withAaSlug()` derives Artificial Analysis slugs from OpenRouter IDs (strip provider, dots→hyphens, strip colon suffixes). Validation script confirms correct matching for major models.
- **v1.0.0** with updated README, docs/api.md, and CHANGELOG.

332 tests passing, clean build.

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composable enrichers for model augmentation (classification, display labels, artificial-analysis slug)
  * Unified apiSlugs structure replacing prior per-field identifiers

* **Documentation**
  * Updated docs and examples showing enrichment composition and new identifier usage
  * Added changelog for 1.0.0

* **Tests**
  * Expanded test coverage for enrichers, slug derivation, and API identifier handling

* **Chores**
  * Bumped release to 1.0.0
  * Added .env to VCS ignore
  * Added validation tooling for slug derivation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->