### PR TITLE
fix: include README.md in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "README.md"
   ],
   "sideEffects": false,
   "engines": {


### PR DESCRIPTION
## Summary

- Add `README.md` to the `files` array in `package.json` so it shows up on the npm package page
- The `files` field is an allowlist, so specifying only `dist` excluded the README