### PR TITLE
refactor: move example descriptions to docs pages, rename Recipes to Scenarios

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -76,12 +76,13 @@ export default defineConfig({
               ],
             },
             {
-              label: "Recipes",
+              label: "Scenarios",
               items: [
-                { label: "LMArena Benchmarks", slug: "examples/lmarena-benchmarks" },
-                { label: "AA Benchmarks", slug: "examples/aa-benchmarks" },
-                { label: "Multi-Benchmark", slug: "examples/multi-benchmark" },
-                { label: "Frontier vs. Open-Weight", slug: "examples/frontier-vs-open-weight" },
+                { label: "Open vs. Closed", slug: "examples/frontier-vs-open-weight" },
+                { label: "Open vs. Closed (Benchmarked)", slug: "examples/frontier-vs-open-weight-benchmarked" },
+                { label: "Human Preference Ranking", slug: "examples/lmarena-benchmarks" },
+                { label: "Objective Quality Ranking", slug: "examples/aa-benchmarks" },
+                { label: "Blending Multiple Sources", slug: "examples/multi-benchmark" },
               ],
             },
           ],

--- a/docs/src/content/docs/examples/aa-benchmarks.mdx
+++ b/docs/src/content/docs/examples/aa-benchmarks.mdx
@@ -1,9 +1,15 @@
 ---
-title: AA Benchmarks
+title: Objective Quality Ranking
 description: Find the smartest model for your budget using Artificial Analysis benchmark data.
 ---
 
 import { Code } from '@astrojs/starlight/components';
 import example from '@examples/aa-benchmarks.ts?raw';
+
+[Artificial Analysis](https://artificialanalysis.ai) maintains an intelligence index that composites scores across standardized benchmarks (MMLU, GPQA, HumanEval, etc.) into a single quality number per model. Unlike arena-style human preference scores, this measures objective task performance.
+
+This example uses the intelligence index to find the highest-quality models under a cost ceiling -- useful when you're building a high-volume pipeline where cost matters but you don't want to sacrifice intelligence. Requires an API key from artificialanalysis.ai (set `ARTIFICIAL_ANALYSIS_API_KEY`).
+
+See [Human Preference Ranking](/examples/lmarena-benchmarks) for a free alternative using human preference data.
 
 <Code code={example} lang="ts" title="aa-benchmarks.ts" />

--- a/docs/src/content/docs/examples/frontier-vs-open-weight-benchmarked.mdx
+++ b/docs/src/content/docs/examples/frontier-vs-open-weight-benchmarked.mdx
@@ -1,0 +1,15 @@
+---
+title: Open vs. Closed (Benchmarked)
+description: Compare open and closed models using objective quality benchmarks from Artificial Analysis.
+---
+
+import { Code } from '@astrojs/starlight/components';
+import example from '@examples/frontier-vs-open-weight-benchmarked.ts?raw';
+
+The [basic Open vs. Closed](/examples/frontier-vs-open-weight) example compares models using only metadata (cost, recency, context window). That's enough to see the shape of the landscape, but when you're making a real deployment decision you want actual quality data behind the scores.
+
+This version enriches the same comparison with the [Artificial Analysis](https://artificialanalysis.ai) intelligence index, a composite of standardized benchmarks (MMLU, GPQA, HumanEval, and others). Now the gap between frontier and open-weight models reflects measured task performance, not just pricing and release dates.
+
+Requires `ARTIFICIAL_ANALYSIS_API_KEY`. AA also exposes category-specific scores (coding, math) if your comparison is narrower than general intelligence.
+
+<Code code={example} lang="ts" title="frontier-vs-open-weight-benchmarked.ts" />

--- a/docs/src/content/docs/examples/frontier-vs-open-weight.mdx
+++ b/docs/src/content/docs/examples/frontier-vs-open-weight.mdx
@@ -1,9 +1,15 @@
 ---
-title: Frontier vs. Open-Weight
+title: Open vs. Closed
 description: Compare top frontier and open-weight models head-to-head.
 ---
 
 import { Code } from '@astrojs/starlight/components';
 import example from '@examples/frontier-vs-open-weight.ts?raw';
+
+Your team has been told you can't use external APIs and must host models locally. That means open-weight only. But how much are you giving up compared to the best frontier models?
+
+The key is scoring everything against the same candidate set so the scores are directly comparable. If you scored frontier and open-weight models separately, the scores would be relative to different ranges and you couldn't compare them.
+
+Want real benchmark data behind these scores? See [Open vs. Closed (Benchmarked)](/examples/frontier-vs-open-weight-benchmarked).
 
 <Code code={example} lang="ts" title="frontier-vs-open-weight.ts" />

--- a/docs/src/content/docs/examples/lmarena-benchmarks.mdx
+++ b/docs/src/content/docs/examples/lmarena-benchmarks.mdx
@@ -1,9 +1,15 @@
 ---
-title: LMArena Benchmarks
+title: Human Preference Ranking
 description: Score models by human preference using crowdsourced LMArena data.
 ---
 
 import { Code } from '@astrojs/starlight/components';
 import example from '@examples/lmarena-benchmarks.ts?raw';
+
+[LMArena](https://lmarena.ai) (formerly Chatbot Arena) ranks models based on crowdsourced blind comparisons: real users chat with two anonymous models side by side and vote for the response they prefer. The resulting ELO-style scores reflect what people actually like, which can differ from what performs best on standardized benchmarks.
+
+This example uses arena scores as the primary signal for picking a conversational model, with cost and recency as secondary factors. LMArena data is free and requires no API key.
+
+See [Objective Quality Ranking](/examples/aa-benchmarks) for objective benchmark scoring via Artificial Analysis.
 
 <Code code={example} lang="ts" title="lmarena-benchmarks.ts" />

--- a/docs/src/content/docs/examples/multi-benchmark.mdx
+++ b/docs/src/content/docs/examples/multi-benchmark.mdx
@@ -1,9 +1,15 @@
 ---
-title: Multi-Benchmark
+title: Blending Multiple Sources
 description: Combine human preference and objective benchmarks for well-rounded model selection.
 ---
 
 import { Code } from '@astrojs/starlight/components';
 import example from '@examples/multi-benchmark.ts?raw';
+
+No single benchmark tells the whole story. Arena scores reflect what people prefer in conversation; objective benchmarks measure raw task performance. A model can score well on standardized tests but feel robotic, or charm users while fumbling at structured tasks.
+
+This example combines two independent quality signals -- LMArena human preference and Artificial Analysis intelligence index -- so models that rank highly on both rise to the top. Cost and recency act as tiebreakers.
+
+Requires `ARTIFICIAL_ANALYSIS_API_KEY` for AA data. LMArena is free.
 
 <Code code={example} lang="ts" title="multi-benchmark.ts" />

--- a/examples/aa-benchmarks.ts
+++ b/examples/aa-benchmarks.ts
@@ -1,19 +1,4 @@
-/**
- * Smartest Model for Your Budget with Artificial Analysis
- *
- * Artificial Analysis maintains an intelligence index that composites
- * scores across standardized benchmarks (MMLU, GPQA, HumanEval, etc.)
- * into a single quality number per model. Unlike arena-style human
- * preference scores, this measures objective task performance.
- *
- * This example uses the intelligence index to find the highest-quality
- * models under a cost ceiling -- useful when you're building a
- * high-volume pipeline where cost matters but you don't want to
- * sacrifice intelligence.
- *
- * Requires an API key from artificialanalysis.ai (set ARTIFICIAL_ANALYSIS_API_KEY).
- * See lmarena-benchmarks.ts for a free alternative using human preference data.
- */
+// Objective Quality Ranking -- find the smartest model using Artificial Analysis benchmarks.
 
 import {
   fromModelsDev, recommend,

--- a/examples/frontier-vs-open-weight-benchmarked.ts
+++ b/examples/frontier-vs-open-weight-benchmarked.ts
@@ -1,0 +1,88 @@
+// Open vs. Closed (Benchmarked) -- compare open and closed models using AA quality data.
+
+import {
+  fromModelsDev, recommend,
+  minMaxCriterion, matchesModel,
+  costEfficiency, recency,
+  ALL_KNOWN_PROVIDERS,
+  type Model,
+} from "pickai";
+
+const aaKey = process.env.ARTIFICIAL_ANALYSIS_API_KEY;
+if (!aaKey) {
+  console.error("Set ARTIFICIAL_ANALYSIS_API_KEY to run this example.");
+  process.exit(1);
+}
+
+const models = await fromModelsDev();
+
+// Fetch benchmark data from Artificial Analysis (requires API key)
+const response = await fetch(
+  "https://artificialanalysis.ai/api/v2/data/llms/models",
+  { headers: { "x-api-key": aaKey } },
+);
+if (!response.ok) throw new Error(`AA fetch failed: ${response.status}`);
+const aaData = await response.json();
+
+// The intelligence index composites scores across standardized benchmarks
+// (MMLU, GPQA, HumanEval, etc.) into a single quality number per model.
+// AA also exposes category-specific scores (coding_index, math_index) you
+// could use instead if your use case is narrower.
+const benchmarks = aaData.data
+  .filter((m: Record<string, unknown>) => m.evaluations)
+  .map((m: Record<string, unknown>) => {
+    const evals = m.evaluations as Record<string, number | null>;
+    return {
+      slug: m.slug as string,
+      quality: evals.artificial_analysis_intelligence_index ?? undefined,
+    };
+  });
+
+// Enrich models with quality scores so they flow through to results
+type QualityModel = Model & { quality?: number };
+const qualityModels: QualityModel[] = models.map((m) => {
+  const match = benchmarks.find((b: { slug: string }) =>
+    matchesModel(b.slug, m.id),
+  );
+  return { ...m, quality: match?.quality };
+});
+
+// Quality is the primary signal -- this is what the metadata-only version lacks
+const qualityScore = minMaxCriterion((model: QualityModel) => model.quality);
+
+const qualityProfile = {
+  criteria: [
+    { criterion: qualityScore, weight: 5 },
+    { criterion: costEfficiency, weight: 2 },
+    { criterion: recency, weight: 1 },
+  ],
+};
+
+// Score all models together so scores are on the same scale
+const all = recommend(qualityModels, qualityProfile, {
+  filter: { providers: [...ALL_KNOWN_PROVIDERS] },
+  limit: 100,
+});
+
+// Split the results by open-weight vs frontier
+const topOpen = all.filter((m) => m.openWeights).slice(0, 5);
+const topFrontier = all.filter((m) => !m.openWeights).slice(0, 5);
+
+const format = (rows: typeof topOpen) =>
+  rows.map((m) => ({
+    Score: +m.score.toFixed(3),
+    Model: m.name,
+    Provider: m.provider,
+    Quality: m.quality ?? "n/a",
+    Cost: m.cost?.input != null ? `$${m.cost.input}/M` : "n/a",
+  }));
+
+console.log("--- Top 5 Frontier ---");
+console.table(format(topFrontier));
+
+console.log("--- Top 5 Open-Weight ---");
+console.table(format(topOpen));
+
+// Compare the gap using benchmark-backed scores
+const gap = topFrontier[0].score - topOpen[0].score;
+console.log(`Gap: ${(gap * 100).toFixed(1)}% score difference between top frontier and top open-weight`);

--- a/examples/frontier-vs-open-weight.ts
+++ b/examples/frontier-vs-open-weight.ts
@@ -1,15 +1,4 @@
-/**
- * Frontier vs. Open-Weight Comparison
- *
- * Scenario: your team has been told you can't use external APIs and
- * must host models locally. That means open-weight only. But how much
- * are you giving up compared to the best frontier models?
- *
- * The key is scoring everything against the same candidate set so the
- * scores are directly comparable. If you scored frontier and open-weight
- * models separately, the scores would be relative to different ranges
- * and you couldn't compare them.
- */
+// Open vs. Closed -- compare frontier and open-weight models on the same scale.
 
 import {
   fromModelsDev, recommend,

--- a/examples/lmarena-benchmarks.ts
+++ b/examples/lmarena-benchmarks.ts
@@ -1,18 +1,4 @@
-/**
- * Human Preference Scoring with LMArena
- *
- * LMArena (formerly Chatbot Arena) ranks models based on crowdsourced
- * blind comparisons: real users chat with two anonymous models side by
- * side and vote for the response they prefer. The resulting ELO-style
- * scores reflect what people actually like, which can differ from what
- * performs best on standardized benchmarks.
- *
- * This example uses arena scores as the primary signal for picking a
- * conversational model, with cost and recency as secondary factors.
- *
- * LMArena data is free and requires no API key.
- * See aa-benchmarks.ts for objective benchmark scoring via Artificial Analysis.
- */
+// Human Preference Ranking -- score models using crowdsourced LMArena data.
 
 import {
   fromModelsDev, recommend,

--- a/examples/multi-benchmark.ts
+++ b/examples/multi-benchmark.ts
@@ -1,18 +1,4 @@
-/**
- * Triangulating Quality from Multiple Benchmark Sources
- *
- * No single benchmark tells the whole story. Arena scores reflect what
- * people prefer in conversation; objective benchmarks measure raw task
- * performance. A model can score well on standardized tests but feel
- * robotic, or charm users while fumbling at structured tasks.
- *
- * This example combines two independent quality signals -- LMArena
- * human preference and Artificial Analysis intelligence index -- so
- * models that rank highly on both rise to the top. Cost and recency
- * act as tiebreakers.
- *
- * Requires ARTIFICIAL_ANALYSIS_API_KEY for AA data. LMArena is free.
- */
+// Blending Multiple Sources -- combine LMArena and Artificial Analysis signals.
 
 import {
   fromModelsDev, recommend,


### PR DESCRIPTION
## Summary

Docs and examples restructure. No changes to `src` or the public API.

- Moves the scenario/benchmark example descriptions out of the `examples/*.ts` docblock headers and into the corresponding docs `.mdx` pages, where they render as prose above the code sample. The example source files are trimmed to a single one-line comment so they stay copy-ready.
- Renames the "Recipes" nav section to "Scenarios" and relabels each example around the decision it supports rather than the tool it uses: Open vs. Closed, Open vs. Closed (Benchmarked), Human Preference Ranking, Objective Quality Ranking, Blending Multiple Sources.
- Adds a new example, "Open vs. Closed (Benchmarked)", that enriches the metadata-only Open vs. Closed comparison with the Artificial Analysis intelligence index so the frontier-vs-open-weight gap reflects measured task performance. Related pages cross-link each other.

## Verified

- All five scenario pages return 200 from a local Astro dev build.
- Every example (including the new one) typechecks clean against the current built API.
- Internal cross-links resolve to existing pages.

## Follow-ups (intentionally not in this PR)

- No CHANGELOG entry yet for the rename and the new example.
- README still labels the benchmark-example links with the old shorthand (LMArena, AA, Multi-Benchmark) and does not mention the new benchmarked example.
- Concepts example pages remain code-only while Scenarios pages now lead with prose. Confirm that split is intended (Concepts examples are backed by dedicated concept docs, so it may be deliberate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark-based example for comparing open and closed models.
  * Introduced updated example pages for human preference ranking, objective quality ranking, and blending multiple sources.

* **Documentation**
  * Renamed the **Examples** sidebar section from **Recipes** to **Scenarios**.
  * Refreshed example titles, descriptions, and navigation links to better reflect the updated comparison workflows.
  * Expanded explanatory copy across the example pages for clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->